### PR TITLE
Frontend: apply template variables

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -2,7 +2,7 @@ import { DataSourceInstanceSettings, ScopedVars, DataQueryResponse, DataQueryReq
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { SitewiseCache } from 'sitewiseCache';
 
-import { SitewiseQuery, SitewiseOptions, SitewiseCustomMeta, AssetInfo, isAssetPropertyAggregatesQuery } from './types';
+import { SitewiseQuery, SitewiseOptions, SitewiseCustomMeta } from './types';
 import { Observable } from 'rxjs';
 import { getRequestLooper, MultiRequestTracker } from 'requestLooper';
 import { appendMatchingFrames } from 'appendFrames';
@@ -47,8 +47,8 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
     let txt: string = query.queryType;
     if (query.assetId) {
       const info = cache.getAssetInfoSync(query.assetId);
-      if(!info) {
-        return txt + ' / ' + query.assetId
+      if (!info) {
+        return txt + ' / ' + query.assetId;
       }
       txt += ' / ' + info.name;
 

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -47,15 +47,14 @@ export class SitewiseCache {
       .toPromise();
   }
 
-  getAssetInfoSync(id: string): AssetInfo|undefined {
+  getAssetInfoSync(id: string): AssetInfo | undefined {
     const v = this.assetsById.get(id);
     if (v) {
-      return v
+      return v;
     }
     try {
       (async () => await this.getAssetInfo(id))();
-    }
-    catch {}
+    } catch {}
     return this.assetsById.get(id);
   }
 


### PR DESCRIPTION
This sets template variables for:  region, asset and property.  These are all simple and single valued, but we can look at what is required for other properties

The PR also fixes the display when query is collapsed
