### PR TITLE
setting default region

### DIFF
--- a/pkg/sitewise/client/client.go
+++ b/pkg/sitewise/client/client.go
@@ -43,6 +43,10 @@ func initClient(ctx backend.PluginContext, region string) (Client, error) {
 		return nil, fmt.Errorf("error reading settings: %s", err.Error())
 	}
 
+	if region == "" {
+		region = settings.DefaultRegion
+	}
+
 	cfg, err := gaws.GetAwsConfig(settings, region)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
when fetching the AWS Sitewise client, the default datasource region will be used if the aws region is unset in the request.