### PR TITLE
add ListAssociatedAssetsQuery to QueryEditor

### DIFF
--- a/pkg/models/asset.go
+++ b/pkg/models/asset.go
@@ -22,8 +22,8 @@ type ListAssetsQuery struct {
 
 type ListAssociatedAssetsQuery struct {
 	BaseQuery
-	HierarchyId        string `json:"hierarchyId,omitempty"`
-	TraversalDirection string `json:"traversalDirection,omitempty"`
+	HierarchyId string `json:"hierarchyId,omitempty"`
+	// TraversalDirection is implied from the existance of HierarchyId
 }
 
 func GetDescribeAssetQuery(dq *backend.DataQuery) (*DescribeAssetQuery, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,6 +55,7 @@ func GetQueryHandlers(s *Server) *datasource.QueryTypeMux {
 	mux.HandleFunc(models.QueryTypePropertyAggregate, s.HandlePropertyAggregate)
 	mux.HandleFunc(models.QueryTypePropertyValue, s.HandlePropertyValue)
 	mux.HandleFunc(models.QueryTypeListAssetModels, s.HandleListAssetModels)
+	mux.HandleFunc(models.QueryTypeListAssociatedAssets, s.HandleListAssociatedAssets)
 	mux.HandleFunc(models.QueryTypeListAssets, s.HandleListAssets)
 	mux.HandleFunc(models.QueryTypeDescribeAsset, s.HandleDescribeAsset)
 

--- a/pkg/server/test/list_associated_assets_test.go
+++ b/pkg/server/test/list_associated_assets_test.go
@@ -34,8 +34,7 @@ var listAssociatedAssetsChildrenHappyCase testServerScenarioFn = func(t *testing
 			return false
 		}
 		return testdata.TestTopLevelAssetId == *assetId &&
-			testdata.TestTopLevelAssetHierarchyId == *hierarchyId &&
-			"CHILD" == *traversal
+			testdata.TestTopLevelAssetHierarchyId == *hierarchyId
 	})
 
 	mockSw.On("ListAssociatedAssetsWithContext", mock.Anything, argMatcher).Return(&assets, nil)
@@ -43,7 +42,6 @@ var listAssociatedAssetsChildrenHappyCase testServerScenarioFn = func(t *testing
 	query := models.ListAssociatedAssetsQuery{}
 	query.AssetId = testdata.TestTopLevelAssetId
 	query.HierarchyId = testdata.TestTopLevelAssetHierarchyId
-	query.TraversalDirection = "CHILD"
 
 	return &testScenario{
 		name: "ListAssociatedAssetsChildHappyCase",
@@ -83,7 +81,6 @@ var listAssociatedAssetsParentHappyCase testServerScenarioFn = func(t *testing.T
 
 	query := models.ListAssociatedAssetsQuery{}
 	query.AssetId = testdata.TestAssetId
-	query.TraversalDirection = "PARENT"
 
 	return &testScenario{
 		name: "ListAssociatedAssetsParentHappyCase",

--- a/pkg/sitewise/list_associated_assets.go
+++ b/pkg/sitewise/list_associated_assets.go
@@ -20,10 +20,9 @@ func ListAssociatedAssets(ctx context.Context, client client.Client, query model
 
 	if query.HierarchyId != "" {
 		hierarchyId = aws.String(query.HierarchyId)
-	}
-
-	if query.TraversalDirection != "" {
-		traversalDirection = aws.String(query.TraversalDirection)
+		traversalDirection = aws.String("CHILD")
+	} else {
+		traversalDirection = aws.String("PARENT")
 	}
 
 	resp, err := client.ListAssociatedAssetsWithContext(ctx, &iotsitewise.ListAssociatedAssetsInput{

--- a/pkg/sitewise/test_data_test.go
+++ b/pkg/sitewise/test_data_test.go
@@ -189,7 +189,6 @@ func TestGenerateTestData(t *testing.T) {
 		query := models.ListAssociatedAssetsQuery{}
 		query.AssetId = testdata.TestTopLevelAssetId
 		query.HierarchyId = testdata.TestTopLevelAssetHierarchyId
-		query.TraversalDirection = "CHILD"
 		resp, err := ListAssociatedAssets(ctx, client, query)
 		if err != nil {
 			t.Fatal(err)
@@ -202,7 +201,6 @@ func TestGenerateTestData(t *testing.T) {
 		ctx := context.Background()
 		query := models.ListAssociatedAssetsQuery{}
 		query.AssetId = testdata.TestAssetId
-		query.TraversalDirection = "PARENT"
 		resp, err := ListAssociatedAssets(ctx, client, query)
 		if err != nil {
 			t.Fatal(err)

--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -34,6 +34,7 @@ export class QueryEditor extends PureComponent<Props> {
         return null; // nothing required
       case QueryType.ListAssets:
         return <ListAssetsQueryEditor {...this.props} query={query as ListAssetsQuery} />;
+      case QueryType.ListAssociatedAssets:
       case QueryType.PropertyValue:
       case QueryType.PropertyAggregate:
       case QueryType.PropertyValueHistory:

--- a/src/queryInfo.ts
+++ b/src/queryInfo.ts
@@ -11,6 +11,8 @@ import {
   SiteWiseResolution,
   AssetInfo,
   AssetPropertyInfo,
+  ListAssociatedAssetsQuery,
+  isListAssociatedAssetsQuery,
 } from './types';
 
 export interface QueryTypeInfo extends SelectableValue<QueryType> {
@@ -63,6 +65,13 @@ export const siteWisteQueryTypes: QueryTypeInfo[] = [
     defaultQuery: {} as ListAssetModelsQuery,
     helpURL: 'https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_GetAssetPropertyAggregates.html',
   },
+  {
+    label: 'List associated assets',
+    value: QueryType.ListAssociatedAssets,
+    description: 'Retrieves a paginated list of associated assets.',
+    defaultQuery: {} as ListAssociatedAssetsQuery,
+    helpURL: 'https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssociatedAssets.html',
+  },
 ];
 
 export function changeQueryType(q: SitewiseQuery, info: QueryTypeInfo): SitewiseQuery {
@@ -74,10 +83,14 @@ export function changeQueryType(q: SitewiseQuery, info: QueryTypeInfo): Sitewise
     ...q,
     queryType: info.value,
   };
+  const a = copy as any;
 
-  // TODO: for each query type, remove the unused fields
-
-  console.log('CHANGE', q, copy);
+  if (isListAssociatedAssetsQuery(copy)) {
+    delete a.timeOrdering;
+    delete a.filter;
+    delete a.resolution;
+    delete a.aggregates;
+  }
 
   return copy;
 }

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -157,6 +157,8 @@ export class SitewiseCache {
 
 export function frameToAssetInfo(res: DescribeAssetResult): AssetInfo {
   const properties: AssetPropertyInfo[] = JSON.parse(res.properties);
+  const hierarchy: AssetPropertyInfo[] = JSON.parse(res.hierarchies); // has Id, Name
+
   for (const p of properties) {
     p.value = p.Id;
     p.label = p.Name;
@@ -176,5 +178,9 @@ export function frameToAssetInfo(res: DescribeAssetResult): AssetInfo {
   return {
     ...res,
     properties,
+    hierarchy: hierarchy.map(v => ({
+      label: v.Name,
+      value: v.Id,
+    })),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import { AwsDataSourceJsonData, AwsDataSourceSecureJsonData } from 'common/types
 export enum QueryType {
   ListAssetModels = 'ListAssetModels',
   ListAssets = 'ListAssets',
+  ListAssociatedAssets = 'ListAssociatedAssets',
   DescribeAsset = 'DescribeAsset',
   PropertyValue = 'PropertyValue',
   PropertyValueHistory = 'PropertyValueHistory',
@@ -80,6 +81,17 @@ export function isListAssetsQuery(q?: SitewiseQuery): q is ListAssetsQuery {
   return q?.queryType === QueryType.ListAssets;
 }
 
+// https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssociatedAssets.html
+
+export interface ListAssociatedAssetsQuery extends SitewiseQuery {
+  queryType: QueryType.ListAssociatedAssets;
+  hierarchyId?: string; // if empty, will list the parents
+}
+
+export function isListAssociatedAssetsQuery(q?: SitewiseQuery): q is ListAssociatedAssetsQuery {
+  return q?.queryType === QueryType.ListAssociatedAssets;
+}
+
 /**
  * {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssetModels.html}
  */
@@ -144,10 +156,10 @@ export function isPropertyQueryType(queryType?: QueryType): boolean {
 
 // matches native sitewise API with capitals
 export interface AssetPropertyInfo extends SelectableValue<string> {
-  Alias?: string;
-  DataType: string;
   Id: string;
   Name: string;
+  Alias?: string;
+  DataType: string;
   Unit: string;
 
   // Filled in for selectable values
@@ -162,6 +174,7 @@ export interface AssetInfo {
   arn: string; // string
   model_id: string;
   properties: AssetPropertyInfo[];
+  hierarchy: Array<SelectableValue<string>>; // Id is value
 }
 
 /**


### PR DESCRIPTION
Shows parent/children:

![image](https://user-images.githubusercontent.com/705951/98424425-8371b980-2046-11eb-904f-583e6c9e5f77.png)


I changed the API so that "PARENT"/"CHILD" is assumed from the existance of hierarchyId