### PR TITLE
allow for graceful switching of regions within query editor

### DIFF
--- a/src/components/browser/AssetBrowser.tsx
+++ b/src/components/browser/AssetBrowser.tsx
@@ -40,8 +40,7 @@ export class AssetBrowser extends Component<Props, State> {
   }
 
   async componentDidUpdate(oldProps: Props) {
-
-    let update: State = {...this.state}
+    let update: State = { ...this.state };
     let shouldUpdate = false;
 
     if (this.props.region !== oldProps.region) {
@@ -59,7 +58,7 @@ export class AssetBrowser extends Component<Props, State> {
     }
 
     if (shouldUpdate) {
-      this.setState(update)
+      this.setState(update);
     }
   }
 

--- a/src/components/browser/AssetBrowser.tsx
+++ b/src/components/browser/AssetBrowser.tsx
@@ -40,16 +40,26 @@ export class AssetBrowser extends Component<Props, State> {
   }
 
   async componentDidUpdate(oldProps: Props) {
+
+    let update: State = {...this.state}
+    let shouldUpdate = false;
+
     if (this.props.region !== oldProps.region) {
-      const cache = this.props.datasource.getCache(this.props.region);
-      this.setState({ cache });
+      shouldUpdate = true;
+      update.cache = this.props.datasource.getCache(this.props.region);
+      // this.setState({ cache });
     }
     if (this.props.assetId !== oldProps.assetId) {
+      shouldUpdate = true;
       const { cache } = this.state;
       const { assetId } = this.props;
       // Asset changed from the parent... reset state
-      const asset = assetId ? await cache!.getAssetInfo(assetId) : undefined;
-      this.setState({ asset });
+      update.asset = assetId ? await cache!.getAssetInfo(assetId) : undefined;
+      // this.setState({ asset });
+    }
+
+    if (shouldUpdate) {
+      this.setState(update)
     }
   }
 

--- a/src/components/browser/AssetBrowser.tsx
+++ b/src/components/browser/AssetBrowser.tsx
@@ -47,7 +47,7 @@ export class AssetBrowser extends Component<Props, State> {
       shouldUpdate = true;
       update.cache = this.props.datasource.getCache(this.props.region);
     }
-    
+
     if (this.props.assetId !== oldProps.assetId) {
       const { cache } = this.state;
       const { assetId } = this.props;

--- a/src/components/browser/AssetBrowser.tsx
+++ b/src/components/browser/AssetBrowser.tsx
@@ -46,15 +46,14 @@ export class AssetBrowser extends Component<Props, State> {
     if (this.props.region !== oldProps.region) {
       shouldUpdate = true;
       update.cache = this.props.datasource.getCache(this.props.region);
-      // this.setState({ cache });
     }
+    
     if (this.props.assetId !== oldProps.assetId) {
-      shouldUpdate = true;
       const { cache } = this.state;
       const { assetId } = this.props;
+      shouldUpdate = true;
       // Asset changed from the parent... reset state
       update.asset = assetId ? await cache!.getAssetInfo(assetId) : undefined;
-      // this.setState({ asset });
     }
 
     if (shouldUpdate) {

--- a/src/components/browser/BrowseHierarchy.tsx
+++ b/src/components/browser/BrowseHierarchy.tsx
@@ -137,7 +137,7 @@ export class BrowseHierarchy extends Component<Props, State> {
     }
 
     return (
-      <>
+      <div style={{ height: '60vh' }}>
         {asset ? (
           <>
             <this.renderParents />
@@ -161,7 +161,7 @@ export class BrowseHierarchy extends Component<Props, State> {
         )}
         <br />
         {this.renderHierarchies()}
-      </>
+      </div>
     );
   }
 }

--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -77,6 +77,8 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
     const { query } = this.props;
     const assetChanged = query?.assetId !== oldProps?.query?.assetId;
     const propChanged = query?.propertyId !== oldProps?.query?.propertyId;
+    console.log(`assetChanged: ${assetChanged}, propChanged: ${propChanged}`);
+    console.log(`${JSON.stringify(query, undefined, 2)}`)
     if (assetChanged || propChanged) {
       if (!query.assetId) {
         this.setState({ asset: undefined, property: undefined, loading: false });
@@ -228,7 +230,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
   }
 
   render() {
-    const { query } = this.props;
+    const { query, datasource } = this.props;
     const { loading, asset, assets } = this.state;
 
     let current = query.assetId ? assets.find(v => v.value === query.assetId) : undefined;
@@ -261,6 +263,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
         <div className="gf-form">
           <InlineField label="Asset" labelWidth={firstLabelWith} grow={true}>
             <Select
+              key={query.region ? query.region : 'default'}
               isLoading={loading}
               options={assets}
               value={current}
@@ -274,7 +277,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
               menuPlacement="bottom"
             />
           </InlineField>
-          <AssetBrowser {...this.props} assetId={query.assetId} onAssetChanged={this.onSetAssetId} />
+          <AssetBrowser datasource={datasource} region={query.region} assetId={query.assetId} onAssetChanged={this.onSetAssetId} />
         </div>
         {showProp && (
           <>

--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -77,8 +77,6 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
     const { query } = this.props;
     const assetChanged = query?.assetId !== oldProps?.query?.assetId;
     const propChanged = query?.propertyId !== oldProps?.query?.propertyId;
-    console.log(`assetChanged: ${assetChanged}, propChanged: ${propChanged}`);
-    console.log(`${JSON.stringify(query, undefined, 2)}`)
     if (assetChanged || propChanged) {
       if (!query.assetId) {
         this.setState({ asset: undefined, property: undefined, loading: false });
@@ -277,7 +275,12 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
               menuPlacement="bottom"
             />
           </InlineField>
-          <AssetBrowser datasource={datasource} region={query.region} assetId={query.assetId} onAssetChanged={this.onSetAssetId} />
+          <AssetBrowser
+            datasource={datasource}
+            region={query.region}
+            assetId={query.assetId}
+            onAssetChanged={this.onSetAssetId}
+          />
         </div>
         {showProp && (
           <>

--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -26,7 +26,7 @@ export class QueryEditor extends PureComponent<Props> {
 
   onRegionChange = (sel: SelectableValue<string>) => {
     const { onChange, query, onRunQuery } = this.props;
-    onChange({ ...query, region: sel.value });
+    onChange({ ...query, assetId: undefined, propertyId: undefined, region: sel.value });
     onRunQuery();
   };
 

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -110,6 +110,7 @@ export class SitewiseCache {
       refId: 'associatedAssets',
       assetId: assetId,
       hierarchyId: hierarchyId,
+      region: this.region,
     };
 
     return this.ds


### PR DESCRIPTION
- fixed issue where changing region does not cascade to children
- reset the query asset/property ID to `undefined` when switching regions
- fixed sizing issue when asset is undefined in HierachyBrowser