### PR TITLE
update auth sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.35.30
-	github.com/grafana/grafana-aws-sdk v0.0.0-20201117233104-25fc587f10ea
+	github.com/grafana/grafana-aws-sdk v0.0.0-20201208000116-f1b638488d10
 	github.com/grafana/grafana-plugin-sdk-go v0.79.0
 	github.com/magefile/mage v1.10.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -45,10 +45,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.3 h1:x95R7cp+rSeeqAMI2knLtQ0DKlaBhv2NrtrOvafPHRo=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/grafana/grafana-aws-sdk v0.0.0-20201117222900-758568cc97c7 h1:NDMpByQ7Abu3ulPB72kSlXXkzMg4WzOZpeAmo3UFO0Y=
-github.com/grafana/grafana-aws-sdk v0.0.0-20201117222900-758568cc97c7/go.mod h1:+pPo5U+pX0zWimR7YBc7ASeSQfbRkcTyQYqMiAj7G5U=
-github.com/grafana/grafana-aws-sdk v0.0.0-20201117233104-25fc587f10ea h1:OqnewdzXc4YTdpGZSJuW+rowmQP4hpyUowt+634FCYM=
-github.com/grafana/grafana-aws-sdk v0.0.0-20201117233104-25fc587f10ea/go.mod h1:+pPo5U+pX0zWimR7YBc7ASeSQfbRkcTyQYqMiAj7G5U=
+github.com/grafana/grafana-aws-sdk v0.0.0-20201208000116-f1b638488d10 h1:7RUaYOaAidq61AYlPgWvmOguui59iXwY2gc8Uz4DuAE=
+github.com/grafana/grafana-aws-sdk v0.0.0-20201208000116-f1b638488d10/go.mod h1:+pPo5U+pX0zWimR7YBc7ASeSQfbRkcTyQYqMiAj7G5U=
 github.com/grafana/grafana-plugin-sdk-go v0.79.0 h1:7NVEIMlF8G9H7XUdLX9jH/g01FllE1GEBcFvzXZD+Kw=
 github.com/grafana/grafana-plugin-sdk-go v0.79.0/go.mod h1:NvxLzGkVhnoBKwzkst6CFfpMFKwAdIUZ1q8ssuLeF60=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 h1:0IKlLyQ3Hs9nDaiK5cSHAGmcQEIC8l2Ts1u6x5Dfrqg=


### PR DESCRIPTION
This includes two auth fixes:
1. UTC consistenty in timeouts https://github.com/grafana/grafana-aws-sdk/pull/2
2. (not relevant) better migrations for old settings https://github.com/grafana/grafana-aws-sdk/pull/3