### PR TITLE
fixing styling on AssetHierarchyList containers

### DIFF
--- a/src/components/browser/hierarchy/AssetHierarchyList.tsx
+++ b/src/components/browser/hierarchy/AssetHierarchyList.tsx
@@ -11,7 +11,8 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
     container: css`
       width: 100%;
-      height: 60vh;
+      height: auto;
+      margin-top: 10px;
     `,
     listItem: css`
       ${styleMixins.listItem(theme)}


### PR DESCRIPTION
When multiple hierarchies are present, the AssetHierarchyList elements have large margins between each. This makes it appear as the other hierarchies are not being loaded.

Changing height to auto with a 10px top margin.