### PR TITLE
Add support for variables in query editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## v1.2.7 (not yet released)
+## v1.3.0
 
 - Add support to define template variables using iot-sitewise datasource queries
+- Add dashboard variable support in query editor
 
 ## v1.2.6
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-sitewise-datasource",
-  "version": "1.2.7-pre",
+  "version": "1.3.0",
   "description": "View IoT Sitewise data in grafana",
   "scripts": {
     "build": "rm -rf dist && grafana-toolkit plugin:build && mage build:backend",

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -111,6 +111,7 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
     const templateSrv = getTemplateSrv();
     return {
       ...query,
+      propertyAlias: templateSrv.replace(query.propertyAlias, scopedVars),
       region: templateSrv.replace(query.region || '', scopedVars),
       assetId: templateSrv.replace(query.assetId || '', scopedVars),
       propertyId: templateSrv.replace(query.propertyId || '', scopedVars),

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -4,6 +4,7 @@ import { ListAssetsQuery, ListAssociatedAssetsQuery, QueryType } from 'types';
 import { AssetModelSummary, AssetSummary, DescribeAssetResult } from './queryResponseTypes';
 import { AssetInfo, AssetPropertyInfo } from './types';
 import { map } from 'rxjs/operators';
+import { getTemplateSrv } from '@grafana/runtime';
 
 /**
  * Keep a differnt cache for each region
@@ -152,7 +153,13 @@ export class SitewiseCache {
   }
 
   async getAssetPickerOptions(): Promise<Array<SelectableValue<string>>> {
-    const options: Array<SelectableValue<string>> = [];
+    const options: Array<SelectableValue<string>> = getTemplateSrv()
+      .getVariables()
+      .map((variable) => ({
+        label: `$${variable.label ?? variable.name}`,
+        value: `$${variable.name}`,
+        description: `${variable.type} variable`,
+      }));
     try {
       const topLevel = await this.getTopLevelAssets();
       for (const asset of topLevel) {
@@ -197,10 +204,21 @@ export function frameToAssetInfo(res: DescribeAssetResult): AssetInfo {
       }
     }
   }
+  const options: AssetPropertyInfo[] = getTemplateSrv()
+    .getVariables()
+    .map((variable) => ({
+      Id: '$' + variable.name,
+      Name: '$' + variable.name,
+      DataType: 'string',
+      Unit: '',
+      label: '$' + variable.label ?? variable.name,
+      value: '$' + variable.name,
+      description: `${variable.type} variable`,
+    }));
 
   return {
     ...res,
-    properties,
+    properties: [...options, ...properties],
     hierarchy: hierarchy.map((v) => ({
       label: v.Name,
       value: v.Id,

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -156,9 +156,9 @@ export class SitewiseCache {
     const options: Array<SelectableValue<string>> = getTemplateSrv()
       .getVariables()
       .map((variable) => ({
-        label: `$${variable.label ?? variable.name}`,
-        value: `$${variable.name}`,
-        description: `${variable.type} variable`,
+        label: '${' + (variable.label ?? variable.name) + '}',
+        value: '${' + variable.name + '}',
+        icon: 'arrow-right',
       }));
     try {
       const topLevel = await this.getTopLevelAssets();
@@ -206,15 +206,18 @@ export function frameToAssetInfo(res: DescribeAssetResult): AssetInfo {
   }
   const options: AssetPropertyInfo[] = getTemplateSrv()
     .getVariables()
-    .map((variable) => ({
-      Id: '$' + variable.name,
-      Name: '$' + variable.name,
-      DataType: 'string',
-      Unit: '',
-      label: '$' + variable.label ?? variable.name,
-      value: '$' + variable.name,
-      description: `${variable.type} variable`,
-    }));
+    .map((variable) => {
+      const name = '${' + variable.name + '}';
+      return {
+        Id: name,
+        Name: name,
+        DataType: 'string',
+        Unit: '',
+        label: name,
+        value: name,
+        icon: 'arrow-right',
+      };
+    });
 
   return {
     ...res,


### PR DESCRIPTION
Adds query variables to asset and property dropdowns:
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/360020/172250481-feeb79e0-fbdd-46ed-8f7d-d3469127b608.png">

Related to fixes for #113 
