### PR TITLE
Set property alias and query type to have interactive tooltips

### DIFF
--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -301,7 +301,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
     return (
       <>
         <div className="gf-form">
-          <InlineField label="Property Alias" labelWidth={firstLabelWith} grow={true} tooltip={queryTooltip}>
+          <InlineField label="Property Alias" labelWidth={firstLabelWith} grow={true} tooltip={queryTooltip} interactive>
             <Input
               value={query.propertyAlias}
               onChange={this.onAliasChange}

--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -74,7 +74,7 @@ export class QueryEditor extends PureComponent<Props> {
     return (
       <>
         <div className="gf-form">
-          <InlineField label="Query type" labelWidth={firstLabelWith} grow={true} tooltip={queryTooltip}>
+          <InlineField label="Query type" labelWidth={firstLabelWith} grow={true} tooltip={queryTooltip} interactive>
             <Select
               options={siteWiseQueryTypes}
               value={currentQueryType}


### PR DESCRIPTION
Closes https://github.com/grafana/iot-sitewise-datasource/issues/170 and does the same for `query type` InlineField