### PR TITLE
Replace deprecated setVariableQueryEditor with CustomVariableSupport

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -15,6 +15,7 @@ import { Observable } from 'rxjs';
 import { getRequestLooper, MultiRequestTracker } from 'requestLooper';
 import { appendMatchingFrames } from 'appendFrames';
 import { frameToMetricFindValues } from 'utils';
+import { SitewiseVariableSupport } from './variables';
 
 export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOptions> {
   // Easy access for QueryEditor
@@ -24,6 +25,7 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
   constructor(instanceSettings: DataSourceInstanceSettings<SitewiseOptions>) {
     super(instanceSettings);
     this.options = instanceSettings.jsonData;
+    this.variables = new SitewiseVariableSupport(this);
   }
 
   /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,5 +8,5 @@ import { QueryEditor } from 'components/query/QueryEditor';
 export const plugin = new DataSourcePlugin<DataSource, SitewiseQuery, SitewiseOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
   .setMetadataInspector(MetaInspector)
-  .setVariableQueryEditor(QueryEditor)
   .setQueryEditor(QueryEditor);
+

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,21 @@
+import { Observable } from 'rxjs';
+import { assign } from 'lodash';
+import { SitewiseQuery } from './types';
+import { DataSource } from './DataSource';
+import { DataQueryRequest, DataQueryResponse, CustomVariableSupport } from '@grafana/data';
+import { QueryEditor } from './components/query/QueryEditor';
+
+export class SitewiseVariableSupport extends CustomVariableSupport<DataSource, SitewiseQuery, SitewiseQuery> {
+  constructor(private readonly datasource: DataSource) {
+    super();
+    this.datasource = datasource;
+    this.query = this.query.bind(this);
+  }
+
+  editor = QueryEditor;
+
+  query(request: DataQueryRequest<SitewiseQuery>): Observable<DataQueryResponse> {
+    assign(request.targets, [{ ...request.targets[0], refId: 'A' }]);
+    return this.datasource.query(request);
+  }
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
This replaces the deprecated `setVariableQueryEditor` with `CustomVariableSupport` modeled after what is used in the Athena datasource.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #154

**Special notes for your reviewer**:
I made an attempt to updated the deprecated setVariableQueryEditor. If I'm not mistaken in the build, I think it's working! I modeled it off of what is done in Athena.
Any suggestions are very welcome!

Here's the video of the change:
https://github.com/grafana/iot-sitewise-datasource/assets/4163034/40debff9-1617-499e-8622-3e56e79f142b

Now the regex filters by the name of the values for the regex.  