### PR TITLE
Fix handle expression queries with more than 250 data points

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.194
+	github.com/google/go-cmp v0.5.9
 	github.com/grafana/grafana-aws-sdk v0.15.0
 	github.com/grafana/grafana-plugin-sdk-go v0.161.0
 	github.com/magefile/mage v1.14.0
@@ -31,7 +32,6 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/flatbuffers v22.11.22+incompatible // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grafana/sqlds/v2 v2.3.10 // indirect

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -84,7 +84,8 @@ func (s *Server) handlePropertyValueHistoryQuery(ctx context.Context, req *backe
 	// Expressions need to run synchronously so we set MaxPageAggregations
 	// and MaxDataPoints to infinity to ensure that the query is not paginated.
 	_, isFromExpression := req.Headers["http_X-Grafana-From-Expr"]
-	if isFromExpression {
+	_, isFromAlert := req.Headers["FromAlert"]
+	if isFromAlert || isFromExpression {
 		query.MaxPageAggregations = int(math.Inf(1))
 		query.MaxDataPoints = int64(math.Inf(1))
 	}
@@ -119,7 +120,8 @@ func (s *Server) handlePropertyAggregateQuery(ctx context.Context, req *backend.
 	// Expressions need to run synchronously so we set MaxPageAggregations
 	// and MaxDataPoints to infinity to ensure that the query is not paginated.
 	_, isFromExpression := req.Headers["http_X-Grafana-From-Expr"]
-	if isFromExpression {
+	_, isFromAlert := req.Headers["FromAlert"]
+	if isFromAlert || isFromExpression {
 		query.MaxPageAggregations = int(math.Inf(1))
 		query.MaxDataPoints = int64(math.Inf(1))
 	}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -81,16 +81,24 @@ func (s *Server) handlePropertyValueHistoryQuery(ctx context.Context, req *backe
 		return DataResponseErrorUnmarshal(err)
 	}
 
+	// Expressions need to run synchronously so we set MaxPageAggregations
+	// and MaxDataPoints to infinity to ensure that the query is not paginated.
+	_, isFromExpression := req.Headers["http_X-Grafana-From-Expr"]
+	if isFromExpression {
+		query.MaxPageAggregations = int(math.Inf(1))
+		query.MaxDataPoints = int64(math.Inf(1))
+	}
+
 	frames, err := s.Datasource.HandleGetAssetPropertyValueHistoryQuery(ctx, query)
 	if err != nil {
 		return DataResponseErrorRequestFailed(err)
 	}
 
 	if len(frames) > 0 && query.ResponseFormat == "timeseries" {
-		for _, frame := range frames {
+		for i, frame := range frames {
 			wide, err := data.LongToWide(frame, &data.FillMissing{Mode: data.FillModeNull, Value: math.NaN()})
 			if err == nil {
-				frames = []*data.Frame{wide}
+				frames[i] = wide
 			}
 		}
 	}
@@ -106,6 +114,14 @@ func (s *Server) handlePropertyAggregateQuery(ctx context.Context, req *backend.
 	query, err := models.GetAssetPropertyValueQuery(&q)
 	if err != nil {
 		return DataResponseErrorUnmarshal(err)
+	}
+
+	// Expressions need to run synchronously so we set MaxPageAggregations
+	// and MaxDataPoints to infinity to ensure that the query is not paginated.
+	_, isFromExpression := req.Headers["http_X-Grafana-From-Expr"]
+	if isFromExpression {
+		query.MaxPageAggregations = int(math.Inf(1))
+		query.MaxDataPoints = int64(math.Inf(1))
 	}
 
 	frames, err := s.Datasource.HandleGetAssetPropertyAggregateQuery(ctx, query)

--- a/pkg/server/test/property_value_aggregate_test.go
+++ b/pkg/server/test/property_value_aggregate_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -34,8 +35,8 @@ func Test_property_value_aggregate_query_by_asset_id_and_property_id(t *testing.
 				*entries.PropertyId == "11propid-aaaa-2222-bbbb-3333cccc4444" &&
 				*entries.AggregateTypes[0] == "SUM"
 		}),
-		mock.Anything,
-		mock.Anything,
+		1,
+		0,
 	).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
 		NextToken: Pointer("some-next-token"),
 		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
@@ -105,6 +106,90 @@ func Test_property_value_aggregate_query_by_asset_id_and_property_id(t *testing.
 	})
 }
 
+func Test_property_value_aggregate_with_expression_query_by_asset_id_and_property_id(t *testing.T) {
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On(
+		"BatchGetAssetPropertyAggregatesPageAggregation",
+		mock.Anything,
+		mock.MatchedBy(func(input *iotsitewise.BatchGetAssetPropertyAggregatesInput) bool {
+			entries := *input.Entries[0]
+			return *entries.EntryId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
+				*entries.AssetId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
+				*entries.PropertyId == "11propid-aaaa-2222-bbbb-3333cccc4444" &&
+				*entries.AggregateTypes[0] == "SUM"
+		}),
+		int(math.Inf(1)),
+		int(math.Inf(1)),
+	).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
+		NextToken: Pointer("some-next-token"),
+		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
+			AggregatedValues: []*iotsitewise.AggregatedValue{{
+				Timestamp: Pointer(time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)),
+				Value:     &iotsitewise.Aggregates{Sum: Pointer(1688.6)},
+			}},
+			EntryId: aws.String("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+		}},
+	}, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
+		AssetName: Pointer("Demo Turbine Asset 1"),
+		AssetProperty: &iotsitewise.Property{
+			Name: Pointer("Wind Speed"),
+		},
+	}, nil)
+
+	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyAggregate(context.Background(), &backend.QueryDataRequest{
+		Headers:       map[string]string{"http_X-Grafana-From-Expr": "true"},
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				RefID:     "A",
+				QueryType: models.QueryTypePropertyAggregate,
+				TimeRange: timeRange,
+				JSON: []byte(
+					`{
+					   "region":"us-west-2",
+					   "assetId":"1assetid-aaaa-2222-bbbb-3333cccc4444",
+						 "propertyId":"11propid-aaaa-2222-bbbb-3333cccc4444",
+					   "aggregates":[
+						  "SUM"
+					   ],
+					   "resolution":"1m"
+					}`),
+			},
+		},
+	})
+	require.Nil(t, err)
+	_, ok := qdr.Responses["A"]
+	require.True(t, ok)
+	require.NotNil(t, qdr.Responses["A"].Frames[0])
+
+	expectedFrame := data.NewFrame("Demo Turbine Asset 1 Wind Speed",
+		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)}),
+		data.NewField("sum", nil, []float64{1688.6}),
+	).SetMeta(&data.FrameMeta{
+		Custom: models.SitewiseCustomMeta{
+			NextToken:  "some-next-token",
+			Resolution: "1m",
+			Aggregates: []string{models.AggregateSum},
+		},
+	})
+	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+	}
+
+	mockSw.AssertExpectations(t)
+	mockSw.AssertCalled(t, "DescribeAssetPropertyWithContext", mock.Anything, &iotsitewise.DescribeAssetPropertyInput{
+		AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+		PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
+	})
+}
+
 func Test_property_value_aggregate_query_by_property_alias(t *testing.T) {
 	mockSw := &mocks.SitewiseClient{}
 	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeTimeSeriesOutput{
@@ -121,8 +206,8 @@ func Test_property_value_aggregate_query_by_property_alias(t *testing.T) {
 				*entries.PropertyAlias == "/amazon/renton/1/rpm" &&
 				*entries.AggregateTypes[0] == "SUM"
 		}),
-		mock.Anything,
-		mock.Anything,
+		1,
+		0,
 	).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
 		NextToken: Pointer("some-next-token"),
 		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
@@ -149,6 +234,104 @@ func Test_property_value_aggregate_query_by_property_alias(t *testing.T) {
 	}
 
 	qdr, err := srvr.HandlePropertyAggregate(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				RefID:     "A",
+				QueryType: models.QueryTypePropertyAggregate,
+				TimeRange: timeRange,
+				JSON: []byte(
+					`{
+					   "region":"us-west-2",
+					   "propertyAlias":"/amazon/renton/1/rpm",
+					   "aggregates":[
+						  "SUM"
+					   ],
+					   "resolution":"1m"
+					}`),
+			},
+		},
+	})
+	require.Nil(t, err)
+	_, ok := qdr.Responses["A"]
+	require.True(t, ok)
+	require.NotNil(t, qdr.Responses["A"].Frames[0])
+
+	expectedFrame := data.NewFrame("Demo Turbine Asset 1 Wind Speed",
+		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)}),
+		data.NewField("sum", nil, []float64{1688.6}),
+	).SetMeta(&data.FrameMeta{
+		Custom: models.SitewiseCustomMeta{
+			NextToken:  "some-next-token",
+			Resolution: "1m",
+			Aggregates: []string{models.AggregateSum},
+		},
+	})
+	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+	}
+
+	mockSw.AssertExpectations(t)
+	mockSw.AssertCalled(t,
+		"DescribeTimeSeriesWithContext",
+		mock.Anything,
+		&iotsitewise.DescribeTimeSeriesInput{Alias: Pointer("/amazon/renton/1/rpm")},
+	)
+	mockSw.AssertCalled(t,
+		"DescribeAssetPropertyWithContext",
+		mock.Anything,
+		&iotsitewise.DescribeAssetPropertyInput{
+			AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+			PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
+		},
+	)
+}
+
+func Test_property_value_aggregate_with_expression_query_by_property_alias(t *testing.T) {
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeTimeSeriesOutput{
+		Alias:      Pointer("/amazon/renton/1/rpm"),
+		AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+		PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
+	}, nil)
+	mockSw.On(
+		"BatchGetAssetPropertyAggregatesPageAggregation",
+		mock.Anything,
+		mock.MatchedBy(func(input *iotsitewise.BatchGetAssetPropertyAggregatesInput) bool {
+			entries := *input.Entries[0]
+			return *entries.EntryId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
+				*entries.PropertyAlias == "/amazon/renton/1/rpm" &&
+				*entries.AggregateTypes[0] == "SUM"
+		}),
+		int(math.Inf(1)),
+		int(math.Inf(1)),
+	).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
+		NextToken: Pointer("some-next-token"),
+		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
+			AggregatedValues: []*iotsitewise.AggregatedValue{{
+				Timestamp: Pointer(time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)),
+				Value:     &iotsitewise.Aggregates{Sum: Pointer(1688.6)},
+			}},
+			EntryId: aws.String("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+		}},
+	}, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
+		AssetName: Pointer("Demo Turbine Asset 1"),
+		AssetProperty: &iotsitewise.Property{
+			DataType: Pointer("DOUBLE"),
+			Name:     Pointer("Wind Speed"),
+			Unit:     Pointer("m/s"),
+		},
+	}, nil)
+
+	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyAggregate(context.Background(), &backend.QueryDataRequest{
+		Headers:       map[string]string{"http_X-Grafana-From-Expr": "true"},
 		PluginContext: backend.PluginContext{},
 		Queries: []backend.DataQuery{
 			{

--- a/pkg/server/test/property_value_aggregate_test.go
+++ b/pkg/server/test/property_value_aggregate_test.go
@@ -23,366 +23,176 @@ import (
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client/mocks"
 )
 
-func Test_property_value_aggregate_query_by_asset_id_and_property_id(t *testing.T) {
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On(
-		"BatchGetAssetPropertyAggregatesPageAggregation",
-		mock.Anything,
-		mock.MatchedBy(func(input *iotsitewise.BatchGetAssetPropertyAggregatesInput) bool {
-			entries := *input.Entries[0]
-			return *entries.EntryId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
-				*entries.AssetId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
-				*entries.PropertyId == "11propid-aaaa-2222-bbbb-3333cccc4444" &&
-				*entries.AggregateTypes[0] == "SUM"
-		}),
-		1,
-		0,
-	).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
-		NextToken: Pointer("some-next-token"),
-		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
-			AggregatedValues: []*iotsitewise.AggregatedValue{{
-				Timestamp: Pointer(time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)),
-				Value:     &iotsitewise.Aggregates{Sum: Pointer(1688.6)},
-			}},
-			EntryId: aws.String("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-		}},
-	}, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
-		AssetName: Pointer("Demo Turbine Asset 1"),
-		AssetProperty: &iotsitewise.Property{
-			Name: Pointer("Wind Speed"),
-		},
-	}, nil)
-
-	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+func TestPropertyValueAggregate(t *testing.T) {
+	type test struct {
+		name                                      string
+		query                                     string
+		isExpression                              bool
+		expectedMaxPages                          int
+		expectedMaxResults                        int
+		expectedDescribeTimeSeriesWithContextArgs *iotsitewise.DescribeTimeSeriesInput
 	}
 
-	qdr, err := srvr.HandlePropertyAggregate(context.Background(), &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				RefID:     "A",
-				QueryType: models.QueryTypePropertyAggregate,
-				TimeRange: timeRange,
-				JSON: []byte(
-					`{
-					   "region":"us-west-2",
-					   "assetId":"1assetid-aaaa-2222-bbbb-3333cccc4444",
-						 "propertyId":"11propid-aaaa-2222-bbbb-3333cccc4444",
-					   "aggregates":[
-						  "SUM"
-					   ],
-					   "resolution":"1m"
-					}`),
-			},
+	tests := []test{
+		{
+			name: "query by asset id and property id",
+			query: `{
+				"region":"us-west-2",
+				"assetId":"1assetid-aaaa-2222-bbbb-3333cccc4444",
+				"propertyId":"11propid-aaaa-2222-bbbb-3333cccc4444",
+				"aggregates":["SUM"],
+				"resolution":"1m"
+			}`,
+			expectedMaxPages:   1,
+			expectedMaxResults: 0,
 		},
-	})
-	require.Nil(t, err)
-	_, ok := qdr.Responses["A"]
-	require.True(t, ok)
-	require.NotNil(t, qdr.Responses["A"].Frames[0])
-
-	expectedFrame := data.NewFrame("Demo Turbine Asset 1 Wind Speed",
-		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)}),
-		data.NewField("sum", nil, []float64{1688.6}),
-	).SetMeta(&data.FrameMeta{
-		Custom: models.SitewiseCustomMeta{
-			NextToken:  "some-next-token",
-			Resolution: "1m",
-			Aggregates: []string{models.AggregateSum},
+		{
+			name:         "expression query by asset id and property",
+			isExpression: true,
+			query: `{
+				"region":"us-west-2",
+				"assetId":"1assetid-aaaa-2222-bbbb-3333cccc4444",
+				"propertyId":"11propid-aaaa-2222-bbbb-3333cccc4444",
+				"aggregates":["SUM"],
+				"resolution":"1m"
+			}`,
+			expectedMaxPages:   int(math.Inf(1)),
+			expectedMaxResults: int(math.Inf(1)),
 		},
-	})
-	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+		{
+			name: "query by property alias",
+			query: `{
+				"region":"us-west-2",
+				"propertyAlias":"/amazon/renton/1/rpm",
+				"aggregates":["SUM"],
+				"resolution":"1m"
+			}`,
+			expectedDescribeTimeSeriesWithContextArgs: &iotsitewise.DescribeTimeSeriesInput{Alias: Pointer("/amazon/renton/1/rpm")},
+			expectedMaxPages:   1,
+			expectedMaxResults: 0,
+		},
+		{
+			name:         "expression query by property alias",
+			isExpression: true,
+			query: `{
+				"region":"us-west-2",
+				"propertyAlias":"/amazon/renton/1/rpm",
+				"aggregates":["SUM"],
+				"resolution":"1m"
+			}`,
+			expectedDescribeTimeSeriesWithContextArgs: &iotsitewise.DescribeTimeSeriesInput{Alias: Pointer("/amazon/renton/1/rpm")},
+			expectedMaxPages:   int(math.Inf(1)),
+			expectedMaxResults: int(math.Inf(1)),
+		},
 	}
 
-	mockSw.AssertExpectations(t)
-	mockSw.AssertCalled(t, "DescribeAssetPropertyWithContext", mock.Anything, &iotsitewise.DescribeAssetPropertyInput{
-		AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-		PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
-	})
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockSw := &mocks.SitewiseClient{}
 
-func Test_property_value_aggregate_with_expression_query_by_asset_id_and_property_id(t *testing.T) {
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On(
-		"BatchGetAssetPropertyAggregatesPageAggregation",
-		mock.Anything,
-		mock.MatchedBy(func(input *iotsitewise.BatchGetAssetPropertyAggregatesInput) bool {
-			entries := *input.Entries[0]
-			return *entries.EntryId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
-				*entries.AssetId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
-				*entries.PropertyId == "11propid-aaaa-2222-bbbb-3333cccc4444" &&
-				*entries.AggregateTypes[0] == "SUM"
-		}),
-		int(math.Inf(1)),
-		int(math.Inf(1)),
-	).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
-		NextToken: Pointer("some-next-token"),
-		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
-			AggregatedValues: []*iotsitewise.AggregatedValue{{
-				Timestamp: Pointer(time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)),
-				Value:     &iotsitewise.Aggregates{Sum: Pointer(1688.6)},
-			}},
-			EntryId: aws.String("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-		}},
-	}, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
-		AssetName: Pointer("Demo Turbine Asset 1"),
-		AssetProperty: &iotsitewise.Property{
-			Name: Pointer("Wind Speed"),
-		},
-	}, nil)
+			if tc.expectedDescribeTimeSeriesWithContextArgs != nil {
+				mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeTimeSeriesOutput{
+					Alias:      Pointer("/amazon/renton/1/rpm"),
+					AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+					PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
+				}, nil)
+			}
 
-	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+			mockSw.On(
+				"BatchGetAssetPropertyAggregatesPageAggregation",
+				mock.Anything,
+				mock.MatchedBy(func(input *iotsitewise.BatchGetAssetPropertyAggregatesInput) bool {
+					entries := *input.Entries[0]
 
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+					if tc.expectedDescribeTimeSeriesWithContextArgs != nil {
+						return *entries.EntryId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
+							*entries.PropertyAlias == "/amazon/renton/1/rpm" &&
+							*entries.AggregateTypes[0] == "SUM"
+					} else {
+						return *entries.EntryId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
+							*entries.AssetId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
+							*entries.PropertyId == "11propid-aaaa-2222-bbbb-3333cccc4444" &&
+							*entries.AggregateTypes[0] == "SUM"
+					}
+				}),
+				tc.expectedMaxPages,
+				tc.expectedMaxResults,
+			).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
+				NextToken: Pointer("some-next-token"),
+				SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
+					AggregatedValues: []*iotsitewise.AggregatedValue{{
+						Timestamp: Pointer(time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)),
+						Value:     &iotsitewise.Aggregates{Sum: Pointer(1688.6)},
+					}},
+					EntryId: aws.String("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+				}},
+			}, nil)
+
+			mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
+				AssetName: Pointer("Demo Turbine Asset 1"),
+				AssetProperty: &iotsitewise.Property{
+					DataType: Pointer("DOUBLE"),
+					Name:     Pointer("Wind Speed"),
+					Unit:     Pointer("m/s"),
+				},
+			}, nil)
+
+			srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+
+			sitewise.GetCache = func() *cache.Cache {
+				return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+			}
+
+			query := &backend.QueryDataRequest{
+				PluginContext: backend.PluginContext{},
+				Queries: []backend.DataQuery{
+					{
+						RefID:     "A",
+						QueryType: models.QueryTypePropertyAggregate,
+						TimeRange: timeRange,
+						JSON:      []byte(tc.query),
+					},
+				},
+			}
+
+			if tc.isExpression {
+				query.Headers = map[string]string{"http_X-Grafana-From-Expr": "true"}
+			}
+
+			qdr, err := srvr.HandlePropertyAggregate(context.Background(), query)
+			require.Nil(t, err)
+			_, ok := qdr.Responses["A"]
+			require.True(t, ok)
+			require.NotNil(t, qdr.Responses["A"].Frames[0])
+
+			expectedFrame := data.NewFrame("Demo Turbine Asset 1 Wind Speed",
+				data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)}),
+				data.NewField("sum", nil, []float64{1688.6}),
+			).SetMeta(&data.FrameMeta{
+				Custom: models.SitewiseCustomMeta{
+					NextToken:  "some-next-token",
+					Resolution: "1m",
+					Aggregates: []string{models.AggregateSum},
+				},
+			})
+			if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			mockSw.AssertExpectations(t)
+			if tc.expectedDescribeTimeSeriesWithContextArgs != nil {
+				mockSw.AssertCalled(t,
+					"DescribeTimeSeriesWithContext",
+					mock.Anything,
+					tc.expectedDescribeTimeSeriesWithContextArgs,
+				)
+			}
+			mockSw.AssertCalled(t, "DescribeAssetPropertyWithContext", mock.Anything, &iotsitewise.DescribeAssetPropertyInput{
+				AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+				PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
+			})
+		})
 	}
-
-	qdr, err := srvr.HandlePropertyAggregate(context.Background(), &backend.QueryDataRequest{
-		Headers:       map[string]string{"http_X-Grafana-From-Expr": "true"},
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				RefID:     "A",
-				QueryType: models.QueryTypePropertyAggregate,
-				TimeRange: timeRange,
-				JSON: []byte(
-					`{
-					   "region":"us-west-2",
-					   "assetId":"1assetid-aaaa-2222-bbbb-3333cccc4444",
-						 "propertyId":"11propid-aaaa-2222-bbbb-3333cccc4444",
-					   "aggregates":[
-						  "SUM"
-					   ],
-					   "resolution":"1m"
-					}`),
-			},
-		},
-	})
-	require.Nil(t, err)
-	_, ok := qdr.Responses["A"]
-	require.True(t, ok)
-	require.NotNil(t, qdr.Responses["A"].Frames[0])
-
-	expectedFrame := data.NewFrame("Demo Turbine Asset 1 Wind Speed",
-		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)}),
-		data.NewField("sum", nil, []float64{1688.6}),
-	).SetMeta(&data.FrameMeta{
-		Custom: models.SitewiseCustomMeta{
-			NextToken:  "some-next-token",
-			Resolution: "1m",
-			Aggregates: []string{models.AggregateSum},
-		},
-	})
-	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-		t.Errorf("Result mismatch (-want +got):\n%s", diff)
-	}
-
-	mockSw.AssertExpectations(t)
-	mockSw.AssertCalled(t, "DescribeAssetPropertyWithContext", mock.Anything, &iotsitewise.DescribeAssetPropertyInput{
-		AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-		PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
-	})
-}
-
-func Test_property_value_aggregate_query_by_property_alias(t *testing.T) {
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeTimeSeriesOutput{
-		Alias:      Pointer("/amazon/renton/1/rpm"),
-		AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-		PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
-	}, nil)
-	mockSw.On(
-		"BatchGetAssetPropertyAggregatesPageAggregation",
-		mock.Anything,
-		mock.MatchedBy(func(input *iotsitewise.BatchGetAssetPropertyAggregatesInput) bool {
-			entries := *input.Entries[0]
-			return *entries.EntryId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
-				*entries.PropertyAlias == "/amazon/renton/1/rpm" &&
-				*entries.AggregateTypes[0] == "SUM"
-		}),
-		1,
-		0,
-	).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
-		NextToken: Pointer("some-next-token"),
-		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
-			AggregatedValues: []*iotsitewise.AggregatedValue{{
-				Timestamp: Pointer(time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)),
-				Value:     &iotsitewise.Aggregates{Sum: Pointer(1688.6)},
-			}},
-			EntryId: aws.String("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-		}},
-	}, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
-		AssetName: Pointer("Demo Turbine Asset 1"),
-		AssetProperty: &iotsitewise.Property{
-			DataType: Pointer("DOUBLE"),
-			Name:     Pointer("Wind Speed"),
-			Unit:     Pointer("m/s"),
-		},
-	}, nil)
-
-	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
-	}
-
-	qdr, err := srvr.HandlePropertyAggregate(context.Background(), &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				RefID:     "A",
-				QueryType: models.QueryTypePropertyAggregate,
-				TimeRange: timeRange,
-				JSON: []byte(
-					`{
-					   "region":"us-west-2",
-					   "propertyAlias":"/amazon/renton/1/rpm",
-					   "aggregates":[
-						  "SUM"
-					   ],
-					   "resolution":"1m"
-					}`),
-			},
-		},
-	})
-	require.Nil(t, err)
-	_, ok := qdr.Responses["A"]
-	require.True(t, ok)
-	require.NotNil(t, qdr.Responses["A"].Frames[0])
-
-	expectedFrame := data.NewFrame("Demo Turbine Asset 1 Wind Speed",
-		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)}),
-		data.NewField("sum", nil, []float64{1688.6}),
-	).SetMeta(&data.FrameMeta{
-		Custom: models.SitewiseCustomMeta{
-			NextToken:  "some-next-token",
-			Resolution: "1m",
-			Aggregates: []string{models.AggregateSum},
-		},
-	})
-	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-		t.Errorf("Result mismatch (-want +got):\n%s", diff)
-	}
-
-	mockSw.AssertExpectations(t)
-	mockSw.AssertCalled(t,
-		"DescribeTimeSeriesWithContext",
-		mock.Anything,
-		&iotsitewise.DescribeTimeSeriesInput{Alias: Pointer("/amazon/renton/1/rpm")},
-	)
-	mockSw.AssertCalled(t,
-		"DescribeAssetPropertyWithContext",
-		mock.Anything,
-		&iotsitewise.DescribeAssetPropertyInput{
-			AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-			PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
-		},
-	)
-}
-
-func Test_property_value_aggregate_with_expression_query_by_property_alias(t *testing.T) {
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeTimeSeriesOutput{
-		Alias:      Pointer("/amazon/renton/1/rpm"),
-		AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-		PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
-	}, nil)
-	mockSw.On(
-		"BatchGetAssetPropertyAggregatesPageAggregation",
-		mock.Anything,
-		mock.MatchedBy(func(input *iotsitewise.BatchGetAssetPropertyAggregatesInput) bool {
-			entries := *input.Entries[0]
-			return *entries.EntryId == "1assetid-aaaa-2222-bbbb-3333cccc4444" &&
-				*entries.PropertyAlias == "/amazon/renton/1/rpm" &&
-				*entries.AggregateTypes[0] == "SUM"
-		}),
-		int(math.Inf(1)),
-		int(math.Inf(1)),
-	).Return(&iotsitewise.BatchGetAssetPropertyAggregatesOutput{
-		NextToken: Pointer("some-next-token"),
-		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyAggregatesSuccessEntry{{
-			AggregatedValues: []*iotsitewise.AggregatedValue{{
-				Timestamp: Pointer(time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)),
-				Value:     &iotsitewise.Aggregates{Sum: Pointer(1688.6)},
-			}},
-			EntryId: aws.String("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-		}},
-	}, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
-		AssetName: Pointer("Demo Turbine Asset 1"),
-		AssetProperty: &iotsitewise.Property{
-			DataType: Pointer("DOUBLE"),
-			Name:     Pointer("Wind Speed"),
-			Unit:     Pointer("m/s"),
-		},
-	}, nil)
-
-	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
-	}
-
-	qdr, err := srvr.HandlePropertyAggregate(context.Background(), &backend.QueryDataRequest{
-		Headers:       map[string]string{"http_X-Grafana-From-Expr": "true"},
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				RefID:     "A",
-				QueryType: models.QueryTypePropertyAggregate,
-				TimeRange: timeRange,
-				JSON: []byte(
-					`{
-					   "region":"us-west-2",
-					   "propertyAlias":"/amazon/renton/1/rpm",
-					   "aggregates":[
-						  "SUM"
-					   ],
-					   "resolution":"1m"
-					}`),
-			},
-		},
-	})
-	require.Nil(t, err)
-	_, ok := qdr.Responses["A"]
-	require.True(t, ok)
-	require.NotNil(t, qdr.Responses["A"].Frames[0])
-
-	expectedFrame := data.NewFrame("Demo Turbine Asset 1 Wind Speed",
-		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)}),
-		data.NewField("sum", nil, []float64{1688.6}),
-	).SetMeta(&data.FrameMeta{
-		Custom: models.SitewiseCustomMeta{
-			NextToken:  "some-next-token",
-			Resolution: "1m",
-			Aggregates: []string{models.AggregateSum},
-		},
-	})
-	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-		t.Errorf("Result mismatch (-want +got):\n%s", diff)
-	}
-
-	mockSw.AssertExpectations(t)
-	mockSw.AssertCalled(t,
-		"DescribeTimeSeriesWithContext",
-		mock.Anything,
-		&iotsitewise.DescribeTimeSeriesInput{Alias: Pointer("/amazon/renton/1/rpm")},
-	)
-	mockSw.AssertCalled(t,
-		"DescribeAssetPropertyWithContext",
-		mock.Anything,
-		&iotsitewise.DescribeAssetPropertyInput{
-			AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
-			PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
-		},
-	)
 }
 
 func Pointer[T any](v T) *T { return &v }

--- a/pkg/server/test/property_value_history_test.go
+++ b/pkg/server/test/property_value_history_test.go
@@ -23,178 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_getPropertyValueBoolean(t *testing.T) {
-	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values-boolean.json"))
-	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-is-windy.json"))
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
-
-	srvr := &server.Server{
-		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
-	}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
-	}
-
-	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				QueryType:     models.QueryTypePropertyValueHistory,
-				RefID:         "A",
-				MaxDataPoints: 100,
-				Interval:      1000,
-				TimeRange:     timeRange,
-				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
-					BaseQuery: models.BaseQuery{
-						AwsRegion:  testdata.AwsRegion,
-						AssetId:    testdata.DemoTurbineAsset1,
-						PropertyId: testdata.TurbinePropAvgWindSpeed,
-					},
-				}),
-			},
-		},
-	})
-	require.Nil(t, err)
-
-	for i, dr := range qdr.Responses {
-		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-boolean", i)
-		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
-	}
-}
-
-func Test_getPropertyValueHistoryFromAliasCaseTable(t *testing.T) {
-	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values.json"))
-	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-avg-wind.json"))
-	propTimeSeries := testdata.GetIoTSitewiseTimeSeries(t, testDataRelativePath("describe-time-series.json"))
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
-	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&propTimeSeries, nil)
-
-	srvr := &server.Server{
-		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
-	}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
-	}
-
-	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				QueryType:     models.QueryTypePropertyValueHistory,
-				RefID:         "A",
-				MaxDataPoints: 100,
-				Interval:      1000,
-				TimeRange:     timeRange,
-				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
-					BaseQuery: models.BaseQuery{
-						AwsRegion:     testdata.AwsRegion,
-						PropertyAlias: testdata.TurbinePropWindSpeedAlias,
-					},
-				}),
-			},
-		},
-	})
-	require.Nil(t, err)
-
-	for i, dr := range qdr.Responses {
-		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-from-alias-table", i)
-		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
-	}
-}
-
-func Test_getPropertyValueHistoryFromAliasCaseTimeSeries(t *testing.T) {
-	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values.json"))
-	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-avg-wind.json"))
-	propTimeSeries := testdata.GetIoTSitewiseTimeSeries(t, testDataRelativePath("describe-time-series.json"))
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
-	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&propTimeSeries, nil)
-
-	srvr := &server.Server{
-		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
-	}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
-	}
-
-	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				QueryType:     models.QueryTypePropertyValueHistory,
-				RefID:         "A",
-				MaxDataPoints: 100,
-				Interval:      1000,
-				TimeRange:     timeRange,
-				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
-					BaseQuery: models.BaseQuery{
-						ResponseFormat: "timeseries",
-						AwsRegion:      testdata.AwsRegion,
-						PropertyAlias:  testdata.TurbinePropWindSpeedAlias,
-					},
-				}),
-			},
-		},
-	})
-	require.Nil(t, err)
-
-	for i, dr := range qdr.Responses {
-		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-from-alias-timeseries", i)
-		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
-	}
-}
-
-func Test_getPropertyValueBooleanFromAlias(t *testing.T) {
-	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values-boolean.json"))
-	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-is-windy.json"))
-	propTimeSeries := testdata.GetIoTSitewiseTimeSeries(t, testDataRelativePath("describe-time-series.json"))
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
-	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&propTimeSeries, nil)
-
-	srvr := &server.Server{
-		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
-	}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
-	}
-
-	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				QueryType:     models.QueryTypePropertyValueHistory,
-				RefID:         "A",
-				MaxDataPoints: 100,
-				Interval:      1000,
-				TimeRange:     timeRange,
-				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
-					BaseQuery: models.BaseQuery{
-						AwsRegion:     testdata.AwsRegion,
-						PropertyAlias: testdata.TurbinePropWindSpeedAlias,
-					},
-				}),
-			},
-		},
-	})
-	require.Nil(t, err)
-
-	for i, dr := range qdr.Responses {
-		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-from-alias-boolean", i)
-		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
-	}
-}
-
 func Test_get_property_value_history_with_default_aka_table_response_format(t *testing.T) {
 	mockSw := &mocks.SitewiseClient{}
 	mockSw.On(
@@ -382,6 +210,178 @@ func Test_get_property_value_history_with_time_series_response_format(t *testing
 			PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
 		},
 	)
+}
+
+func Test_getPropertyValueBoolean(t *testing.T) {
+	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values-boolean.json"))
+	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-is-windy.json"))
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
+
+	srvr := &server.Server{
+		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
+	}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				QueryType:     models.QueryTypePropertyValueHistory,
+				RefID:         "A",
+				MaxDataPoints: 100,
+				Interval:      1000,
+				TimeRange:     timeRange,
+				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
+					BaseQuery: models.BaseQuery{
+						AwsRegion:  testdata.AwsRegion,
+						AssetId:    testdata.DemoTurbineAsset1,
+						PropertyId: testdata.TurbinePropAvgWindSpeed,
+					},
+				}),
+			},
+		},
+	})
+	require.Nil(t, err)
+
+	for i, dr := range qdr.Responses {
+		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-boolean", i)
+		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
+	}
+}
+
+func Test_getPropertyValueHistoryFromAliasCaseTable(t *testing.T) {
+	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values.json"))
+	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-avg-wind.json"))
+	propTimeSeries := testdata.GetIoTSitewiseTimeSeries(t, testDataRelativePath("describe-time-series.json"))
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
+	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&propTimeSeries, nil)
+
+	srvr := &server.Server{
+		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
+	}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				QueryType:     models.QueryTypePropertyValueHistory,
+				RefID:         "A",
+				MaxDataPoints: 100,
+				Interval:      1000,
+				TimeRange:     timeRange,
+				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
+					BaseQuery: models.BaseQuery{
+						AwsRegion:     testdata.AwsRegion,
+						PropertyAlias: testdata.TurbinePropWindSpeedAlias,
+					},
+				}),
+			},
+		},
+	})
+	require.Nil(t, err)
+
+	for i, dr := range qdr.Responses {
+		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-from-alias-table", i)
+		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
+	}
+}
+
+func Test_getPropertyValueHistoryFromAliasCaseTimeSeries(t *testing.T) {
+	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values.json"))
+	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-avg-wind.json"))
+	propTimeSeries := testdata.GetIoTSitewiseTimeSeries(t, testDataRelativePath("describe-time-series.json"))
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
+	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&propTimeSeries, nil)
+
+	srvr := &server.Server{
+		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
+	}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				QueryType:     models.QueryTypePropertyValueHistory,
+				RefID:         "A",
+				MaxDataPoints: 100,
+				Interval:      1000,
+				TimeRange:     timeRange,
+				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
+					BaseQuery: models.BaseQuery{
+						ResponseFormat: "timeseries",
+						AwsRegion:      testdata.AwsRegion,
+						PropertyAlias:  testdata.TurbinePropWindSpeedAlias,
+					},
+				}),
+			},
+		},
+	})
+	require.Nil(t, err)
+
+	for i, dr := range qdr.Responses {
+		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-from-alias-timeseries", i)
+		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
+	}
+}
+
+func Test_getPropertyValueBooleanFromAlias(t *testing.T) {
+	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values-boolean.json"))
+	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-is-windy.json"))
+	propTimeSeries := testdata.GetIoTSitewiseTimeSeries(t, testDataRelativePath("describe-time-series.json"))
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
+	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&propTimeSeries, nil)
+
+	srvr := &server.Server{
+		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
+	}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				QueryType:     models.QueryTypePropertyValueHistory,
+				RefID:         "A",
+				MaxDataPoints: 100,
+				Interval:      1000,
+				TimeRange:     timeRange,
+				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
+					BaseQuery: models.BaseQuery{
+						AwsRegion:     testdata.AwsRegion,
+						PropertyAlias: testdata.TurbinePropWindSpeedAlias,
+					},
+				}),
+			},
+		},
+	})
+	require.Nil(t, err)
+
+	for i, dr := range qdr.Responses {
+		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-from-alias-boolean", i)
+		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
+	}
 }
 
 func Test_get_property_value_history_from_expression_query_with_time_series_response_format(t *testing.T) {

--- a/pkg/server/test/property_value_history_test.go
+++ b/pkg/server/test/property_value_history_test.go
@@ -3,13 +3,18 @@ package test
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go/service/iotsitewise"
+	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise"
 	"github.com/grafana/iot-sitewise-datasource/pkg/testdata"
 	"github.com/patrickmn/go-cache"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 	"github.com/grafana/iot-sitewise-datasource/pkg/models"
 	"github.com/grafana/iot-sitewise-datasource/pkg/server"
@@ -17,91 +22,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-func Test_getPropertyValueHistoryHappyCaseTable(t *testing.T) {
-	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values.json"))
-	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-avg-wind.json"))
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
-
-	srvr := &server.Server{
-		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
-	}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
-	}
-
-	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				QueryType:     models.QueryTypePropertyValueHistory,
-				RefID:         "A",
-				MaxDataPoints: 100,
-				Interval:      1000,
-				TimeRange:     timeRange,
-				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
-					BaseQuery: models.BaseQuery{
-						AwsRegion:  testdata.AwsRegion,
-						AssetId:    testdata.DemoTurbineAsset1,
-						PropertyId: testdata.TurbinePropAvgWindSpeed,
-					},
-				}),
-			},
-		},
-	})
-	require.Nil(t, err)
-
-	for i, dr := range qdr.Responses {
-		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-table", i)
-		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
-	}
-}
-
-func Test_getPropertyValueHistoryHappyCaseTimeSeries(t *testing.T) {
-	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values.json"))
-	propDesc := testdata.GetIotSitewiseAssetProp(t, testDataRelativePath("describe-asset-property-avg-wind.json"))
-	mockSw := &mocks.SitewiseClient{}
-	mockSw.On("BatchGetAssetPropertyValueHistoryPageAggregation", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&propVals, nil)
-	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&propDesc, nil)
-
-	srvr := &server.Server{
-		Datasource: mockedDatasource(mockSw).(*sitewise.Datasource),
-	}
-
-	sitewise.GetCache = func() *cache.Cache {
-		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
-	}
-
-	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{},
-		Queries: []backend.DataQuery{
-			{
-				QueryType:     models.QueryTypePropertyValueHistory,
-				RefID:         "A",
-				MaxDataPoints: 100,
-				Interval:      1000,
-				TimeRange:     timeRange,
-				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
-					BaseQuery: models.BaseQuery{
-						ResponseFormat: "timeseries",
-						AwsRegion:      testdata.AwsRegion,
-						AssetId:        testdata.DemoTurbineAsset1,
-						PropertyId:     testdata.TurbinePropAvgWindSpeed,
-					},
-				}),
-			},
-		},
-	})
-	require.Nil(t, err)
-
-	for i, dr := range qdr.Responses {
-		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-timeseries", i)
-		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
-	}
-}
 
 func Test_getPropertyValueBoolean(t *testing.T) {
 	propVals := testdata.GetIoTSitewisePropHistoryVals(t, testDataRelativePath("property-history-values-boolean.json"))
@@ -273,4 +193,289 @@ func Test_getPropertyValueBooleanFromAlias(t *testing.T) {
 		fname := fmt.Sprintf("%s-%s.golden", "property-history-values-from-alias-boolean", i)
 		experimental.CheckGoldenJSONResponse(t, "../../testdata", fname, &dr, true)
 	}
+}
+
+func Test_get_property_value_history_with_default_aka_table_response_format(t *testing.T) {
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On(
+		"BatchGetAssetPropertyValueHistoryPageAggregation",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&iotsitewise.BatchGetAssetPropertyValueHistoryOutput{
+		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyValueHistorySuccessEntry{
+			{
+				AssetPropertyValueHistory: []*iotsitewise.AssetPropertyValue{
+					{
+						Quality: Pointer("GOOD"),
+						Timestamp: &iotsitewise.TimeInNanos{
+							OffsetInNanos: Pointer(int64(0)),
+							TimeInSeconds: Pointer(int64(1612207200)),
+						},
+						Value: &iotsitewise.Variant{
+							DoubleValue: Pointer(float64(23.8)),
+						},
+					},
+				},
+				EntryId: Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+			},
+		},
+	}, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
+		AssetName: Pointer("Demo Turbine Asset 1"),
+		AssetProperty: &iotsitewise.Property{
+			DataType: Pointer("DOUBLE"),
+			Name:     Pointer("Wind Speed"),
+			Unit:     Pointer("m/s"),
+		},
+	}, nil)
+
+	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				QueryType:     models.QueryTypePropertyValueHistory,
+				RefID:         "A",
+				MaxDataPoints: 100,
+				Interval:      1000,
+				TimeRange:     timeRange,
+				JSON: []byte(
+					`{
+					   "region":"us-west-2",
+					   "assetId":"1assetid-aaaa-2222-bbbb-3333cccc4444",
+						 "propertyId":"11propid-aaaa-2222-bbbb-3333cccc4444"
+					}`),
+			},
+		},
+	})
+	require.Nil(t, err)
+	_, ok := qdr.Responses["A"]
+	require.True(t, ok)
+	require.NotNil(t, qdr.Responses["A"].Frames[0])
+
+	expectedFrame := data.NewFrame("Demo Turbine Asset 1",
+		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 19, 20, 0, 0, time.UTC)}),
+		data.NewField("Wind Speed", nil, []float64{23.8}).SetConfig(&data.FieldConfig{Unit: "m/s"}),
+		data.NewField("quality", nil, []string{"GOOD"}),
+	).SetMeta(&data.FrameMeta{
+		Custom: models.SitewiseCustomMeta{Resolution: "RAW"},
+	})
+	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+	}
+
+	mockSw.AssertExpectations(t)
+	mockSw.AssertCalled(t,
+		"BatchGetAssetPropertyValueHistoryPageAggregation",
+		mock.Anything,
+		mock.Anything,
+		1,
+		100,
+	)
+	mockSw.AssertCalled(t,
+		"DescribeAssetPropertyWithContext",
+		mock.Anything,
+		&iotsitewise.DescribeAssetPropertyInput{
+			AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+			PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
+		},
+	)
+}
+
+func Test_get_property_value_history_with_time_series_response_format(t *testing.T) {
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On(
+		"BatchGetAssetPropertyValueHistoryPageAggregation",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&iotsitewise.BatchGetAssetPropertyValueHistoryOutput{
+		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyValueHistorySuccessEntry{
+			{
+				AssetPropertyValueHistory: []*iotsitewise.AssetPropertyValue{
+					{
+						Quality: Pointer("GOOD"),
+						Timestamp: &iotsitewise.TimeInNanos{
+							OffsetInNanos: Pointer(int64(0)),
+							TimeInSeconds: Pointer(int64(1612207200)),
+						},
+						Value: &iotsitewise.Variant{
+							DoubleValue: Pointer(float64(23.8)),
+						},
+					},
+				},
+				EntryId: Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+			},
+		},
+	}, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
+		AssetName: Pointer("Demo Turbine Asset 1"),
+		AssetProperty: &iotsitewise.Property{
+			DataType: Pointer("DOUBLE"),
+			Name:     Pointer("Wind Speed"),
+			Unit:     Pointer("m/s"),
+		},
+	}, nil)
+
+	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				QueryType:     models.QueryTypePropertyValueHistory,
+				RefID:         "A",
+				MaxDataPoints: 100,
+				Interval:      1000,
+				TimeRange:     timeRange,
+				JSON: []byte(
+					`{
+					   "region":"us-west-2",
+					   "assetId":"1assetid-aaaa-2222-bbbb-3333cccc4444",
+						 "propertyId":"11propid-aaaa-2222-bbbb-3333cccc4444",
+						 "responseFormat":"timeseries"
+					}`),
+			},
+		},
+	})
+	require.Nil(t, err)
+	_, ok := qdr.Responses["A"]
+	require.True(t, ok)
+	require.NotNil(t, qdr.Responses["A"].Frames[0])
+
+	expectedFrame := data.NewFrame("Demo Turbine Asset 1",
+		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 19, 20, 0, 0, time.UTC)}),
+		data.NewField("Wind Speed", data.Labels{"quality": "GOOD"}, []*float64{Pointer(23.8)}),
+	).SetMeta(&data.FrameMeta{
+		Type:   data.FrameTypeTimeSeriesWide,
+		Custom: models.SitewiseCustomMeta{Resolution: "RAW"},
+	})
+	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+	}
+
+	mockSw.AssertExpectations(t)
+	mockSw.AssertCalled(t,
+		"BatchGetAssetPropertyValueHistoryPageAggregation",
+		mock.Anything,
+		mock.Anything,
+		1,
+		100,
+	)
+	mockSw.AssertCalled(t,
+		"DescribeAssetPropertyWithContext",
+		mock.Anything,
+		&iotsitewise.DescribeAssetPropertyInput{
+			AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+			PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
+		},
+	)
+}
+
+func Test_get_property_value_history_from_expression_query_with_time_series_response_format(t *testing.T) {
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On(
+		"BatchGetAssetPropertyValueHistoryPageAggregation",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&iotsitewise.BatchGetAssetPropertyValueHistoryOutput{
+		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyValueHistorySuccessEntry{
+			{
+				AssetPropertyValueHistory: []*iotsitewise.AssetPropertyValue{
+					{
+						Quality: Pointer("GOOD"),
+						Timestamp: &iotsitewise.TimeInNanos{
+							OffsetInNanos: Pointer(int64(0)),
+							TimeInSeconds: Pointer(int64(1612207200)),
+						},
+						Value: &iotsitewise.Variant{
+							DoubleValue: Pointer(float64(23.8)),
+						},
+					},
+				},
+				EntryId: Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+			},
+		},
+	}, nil)
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
+		AssetName: Pointer("Demo Turbine Asset 1"),
+		AssetProperty: &iotsitewise.Property{
+			DataType: Pointer("DOUBLE"),
+			Name:     Pointer("Wind Speed"),
+			Unit:     Pointer("m/s"),
+		},
+	}, nil)
+
+	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyValueHistory(context.Background(), &backend.QueryDataRequest{
+		Headers:       map[string]string{"http_X-Grafana-From-Expr": "true"},
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				QueryType:     models.QueryTypePropertyValueHistory,
+				RefID:         "A",
+				MaxDataPoints: 100,
+				Interval:      1000,
+				TimeRange:     timeRange,
+				JSON: []byte(
+					`{
+					   "region":"us-west-2",
+					   "assetId":"1assetid-aaaa-2222-bbbb-3333cccc4444",
+						 "propertyId":"11propid-aaaa-2222-bbbb-3333cccc4444",
+						 "responseFormat":"timeseries"
+					}`),
+			},
+		},
+	})
+	require.Nil(t, err)
+	_, ok := qdr.Responses["A"]
+	require.True(t, ok)
+	require.NotNil(t, qdr.Responses["A"].Frames[0])
+
+	expectedFrame := data.NewFrame("Demo Turbine Asset 1",
+		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 19, 20, 0, 0, time.UTC)}),
+		data.NewField("Wind Speed", data.Labels{"quality": "GOOD"}, []*float64{Pointer(23.8)}),
+	).SetMeta(&data.FrameMeta{
+		Type:   data.FrameTypeTimeSeriesWide,
+		Custom: models.SitewiseCustomMeta{Resolution: "RAW"},
+	})
+	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+	}
+
+	mockSw.AssertExpectations(t)
+	mockSw.AssertCalled(t,
+		"BatchGetAssetPropertyValueHistoryPageAggregation",
+		mock.Anything,
+		mock.Anything,
+		int(math.Inf(1)),
+		int(math.Inf(1)),
+	)
+	mockSw.AssertCalled(t,
+		"DescribeAssetPropertyWithContext",
+		mock.Anything,
+		&iotsitewise.DescribeAssetPropertyInput{
+			AssetId:    Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+			PropertyId: Pointer("11propid-aaaa-2222-bbbb-3333cccc4444"),
+		},
+	)
 }

--- a/pkg/sitewise/api/property_history.go
+++ b/pkg/sitewise/api/property_history.go
@@ -27,8 +27,8 @@ func historyQueryToInput(query models.AssetPropertyValueQuery) *iotsitewise.Batc
 
 	from, to := util.TimeRangeToUnix(query.TimeRange)
 
-	if query.MaxDataPoints < 1 || query.MaxDataPoints > 250 {
-		query.MaxDataPoints = 250
+	if query.MaxDataPoints < 1 || query.MaxDataPoints > 20000 {
+		query.MaxDataPoints = 20000
 	}
 
 	entries := make([]*iotsitewise.BatchGetAssetPropertyValueHistoryEntry, 0)

--- a/pkg/sitewise/client/client.go
+++ b/pkg/sitewise/client/client.go
@@ -56,7 +56,17 @@ func (c *sitewiseClient) BatchGetAssetPropertyValueHistoryPageAggregation(ctx co
 		if len(output.SuccessEntries) > 0 {
 			count += len(output.SuccessEntries[0].AssetPropertyValueHistory)
 		}
-		success = append(success, output.SuccessEntries...)
+		if len(success) > 0 {
+			for i, entry := range success {
+				for _, successEntry := range output.SuccessEntries {
+					if *successEntry.EntryId == *entry.EntryId {
+						success[i].AssetPropertyValueHistory = append(success[i].AssetPropertyValueHistory, successEntry.AssetPropertyValueHistory...)
+					}
+				}
+			}
+		} else {
+			success = append(success, output.SuccessEntries...)
+		}
 		skipped = append(skipped, output.SkippedEntries...)
 		errors = append(errors, output.ErrorEntries...)
 		nextToken = output.NextToken
@@ -114,7 +124,17 @@ func (c *sitewiseClient) BatchGetAssetPropertyAggregatesPageAggregation(ctx cont
 		if len(output.SuccessEntries) > 0 {
 			count += len(output.SuccessEntries[0].AggregatedValues)
 		}
-		success = append(success, output.SuccessEntries...)
+		if len(success) > 0 {
+			for i, entry := range success {
+				for _, successEntry := range output.SuccessEntries {
+					if *successEntry.EntryId == *entry.EntryId {
+						success[i].AggregatedValues = append(success[i].AggregatedValues, successEntry.AggregatedValues...)
+					}
+				}
+			}
+		} else {
+			success = append(success, output.SuccessEntries...)
+		}
 		skipped = append(skipped, output.SkippedEntries...)
 		errors = append(errors, output.ErrorEntries...)
 		nextToken = output.NextToken

--- a/pkg/sitewise/client/client.go
+++ b/pkg/sitewise/client/client.go
@@ -57,11 +57,17 @@ func (c *sitewiseClient) BatchGetAssetPropertyValueHistoryPageAggregation(ctx co
 			count += len(output.SuccessEntries[0].AssetPropertyValueHistory)
 		}
 		if len(success) > 0 {
-			for i, entry := range success {
-				for _, successEntry := range output.SuccessEntries {
-					if *successEntry.EntryId == *entry.EntryId {
+			for _, successEntry := range output.SuccessEntries {
+				found := false
+				for i, entry := range success {
+					if *entry.EntryId == *successEntry.EntryId {
 						success[i].AssetPropertyValueHistory = append(success[i].AssetPropertyValueHistory, successEntry.AssetPropertyValueHistory...)
+						found = true
+						break
 					}
+				}
+				if !found {
+					success = append(success, successEntry)
 				}
 			}
 		} else {
@@ -125,6 +131,20 @@ func (c *sitewiseClient) BatchGetAssetPropertyAggregatesPageAggregation(ctx cont
 			count += len(output.SuccessEntries[0].AggregatedValues)
 		}
 		if len(success) > 0 {
+			for _, successEntry := range output.SuccessEntries {
+				found := false
+				for i, entry := range success {
+					if *entry.EntryId == *successEntry.EntryId {
+						success[i].AggregatedValues = append(success[i].AggregatedValues, successEntry.AggregatedValues...)
+						found = true
+						break
+					}
+				}
+				if !found {
+					success = append(success, successEntry)
+				}
+			}
+
 			for i, entry := range success {
 				for _, successEntry := range output.SuccessEntries {
 					if *successEntry.EntryId == *entry.EntryId {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

This PR fixes an issue where queries with an expression do not show all data points.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #160, #182, #195

**Special notes for your reviewer**:

To be able to test this, you can use the Sitewise assets in the external dev account. Note, the demo assets live for 7 days before being deleted. If you see an error indicating that the resources can not be found, you can go to the Sitewise dashboard in the AWS console and create demo assets (there is a button to do so in the top right of the dashboard page)

The main issue here is that expression queries do not call the datasource's query method. Instead [if an expression query is present](https://github.com/grafana/grafana/blob/8235f774aa1afb49254861f3d6d3ea691baedde3/public/app/features/query/state/runRequest.ts#L203), the query is handled through the ExpressionDatasource's query handler. Since Sitewise paginates the aggregate and value history queries, we are no longer able to handle the pagination because the query is being executed by the ExecutionDatasources's query handler instead.

In the backend, we can see if a query is executed from the expression datasource by checking a header in the request. If it's a query execution we set the maximum number of datapoints/pages to receive to a high enough number so that we get back all of the data for the request time frame.

Here's a sample of a query that would not have worked before. Previously it would cut off after 250 data points.

Now it should show all of the data points. You can also change it to be a property value history as well.
<img width="845" alt="sample query" src="https://github.com/grafana/iot-sitewise-datasource/assets/19530599/976dc932-49bc-450b-80bd-c67837fb37cd">

Note, when running a property value history query with an expression, you'll need to set the format to `Time series`