### PR TITLE
Fix: Property aggregate queries returning duplicated data

### DIFF
--- a/pkg/sitewise/client/client.go
+++ b/pkg/sitewise/client/client.go
@@ -144,14 +144,6 @@ func (c *sitewiseClient) BatchGetAssetPropertyAggregatesPageAggregation(ctx cont
 					success = append(success, successEntry)
 				}
 			}
-
-			for i, entry := range success {
-				for _, successEntry := range output.SuccessEntries {
-					if *successEntry.EntryId == *entry.EntryId {
-						success[i].AggregatedValues = append(success[i].AggregatedValues, successEntry.AggregatedValues...)
-					}
-				}
-			}
 		} else {
 			success = append(success, output.SuccessEntries...)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where some data points are duplicated.

**Which issue(s) this PR fixes**:

Fixes #200

**Special notes for your reviewer**:

Here's a sample python script that can fetch the expected number of data points for a property aggregate query using boto3. Make sure you have boto3 installed. You may need to update the `assetId`, `propertyId`, `startDate`, and `endDate` if the sample data in external dev has expired and you recreate the demo data. Your Sitewise data source should be configured for the external dev account. You can use the Stat panel and set the calculation value to "Count" to compare the number of data points from the script below (just make sure the time range matches the python script).

```py
import boto3
from datetime import datetime

client = boto3.client('iotsitewise')

# get asset property aggregates
# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iotsitewise/client/get_asset_property_aggregates.html
agg_paginator = client.get_paginator('get_asset_property_aggregates')
agg_iterator = agg_paginator.paginate(
    assetId='fc1cbae5-0a28-4152-b622-35e92493d62e',
    propertyId='490c9933-b87e-4d51-9512-95e7ca476ed9',
    startDate=datetime.fromisoformat('2023-07-18T07:00:00Z'),
    endDate=datetime.fromisoformat('2023-07-19T06:59:59Z'),
    timeOrdering='ASCENDING',
    aggregateTypes=['AVERAGE'],
    resolution='1m',
    maxResults=250,
)
agg_count = 0
for p in agg_iterator:
  agg_count += len(p['aggregatedValues'])
print(agg_count)
```