### PR TITLE
Fix: Query with expression only returns partial data

### DIFF
--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -86,8 +86,8 @@ func (s *Server) handlePropertyValueHistoryQuery(ctx context.Context, req *backe
 	_, isFromExpression := req.Headers["http_X-Grafana-From-Expr"]
 	_, isFromAlert := req.Headers["FromAlert"]
 	if isFromAlert || isFromExpression {
-		query.MaxPageAggregations = int(math.Inf(1))
-		query.MaxDataPoints = int64(math.Inf(1))
+		query.MaxPageAggregations = math.MaxInt32
+		query.MaxDataPoints = math.MaxInt32
 	}
 
 	frames, err := s.Datasource.HandleGetAssetPropertyValueHistoryQuery(ctx, query)
@@ -122,8 +122,8 @@ func (s *Server) handlePropertyAggregateQuery(ctx context.Context, req *backend.
 	_, isFromExpression := req.Headers["http_X-Grafana-From-Expr"]
 	_, isFromAlert := req.Headers["FromAlert"]
 	if isFromAlert || isFromExpression {
-		query.MaxPageAggregations = int(math.Inf(1))
-		query.MaxDataPoints = int64(math.Inf(1))
+		query.MaxPageAggregations = math.MaxInt32
+		query.MaxDataPoints = math.MaxInt32
 	}
 
 	frames, err := s.Datasource.HandleGetAssetPropertyAggregateQuery(ctx, query)

--- a/pkg/server/test/property_value_aggregate_test.go
+++ b/pkg/server/test/property_value_aggregate_test.go
@@ -56,8 +56,8 @@ func TestPropertyValueAggregate(t *testing.T) {
 				"aggregates":["SUM"],
 				"resolution":"1m"
 			}`,
-			expectedMaxPages:   int(math.Inf(1)),
-			expectedMaxResults: int(math.Inf(1)),
+			expectedMaxPages:   math.MaxInt32,
+			expectedMaxResults: math.MaxInt32,
 		},
 		{
 			name: "query by property alias",
@@ -81,8 +81,8 @@ func TestPropertyValueAggregate(t *testing.T) {
 				"resolution":"1m"
 			}`,
 			expectedDescribeTimeSeriesWithContextArgs: &iotsitewise.DescribeTimeSeriesInput{Alias: Pointer("/amazon/renton/1/rpm")},
-			expectedMaxPages:   int(math.Inf(1)),
-			expectedMaxResults: int(math.Inf(1)),
+			expectedMaxPages:   math.MaxInt32,
+			expectedMaxResults: math.MaxInt32,
 		},
 	}
 

--- a/pkg/server/test/property_value_history_test.go
+++ b/pkg/server/test/property_value_history_test.go
@@ -467,8 +467,8 @@ func Test_get_property_value_history_from_expression_query_with_time_series_resp
 		"BatchGetAssetPropertyValueHistoryPageAggregation",
 		mock.Anything,
 		mock.Anything,
-		int(math.Inf(1)),
-		int(math.Inf(1)),
+		math.MaxInt32,
+		math.MaxInt32,
 	)
 	mockSw.AssertCalled(t,
 		"DescribeAssetPropertyWithContext",


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where queries with expression return partial data only. In a previous PR queries with expressions were set to execute completely on the backend before returning data to the frontend. This was done by setting the maximum number of datapoints and pages to fetch to `math.Inf(1)`. This worked locally, but when the Sitewise data source was built, `math.Inf(1)` ended up being a negative number. This caused the backend to only return the first page of data because the function that fetches the data from Sitewise would check if the current number of datapoints/pages is less than the maximum number of datapoints/pages it should fetch https://github.com/grafana/iot-sitewise-datasource/blob/c70aadea564390be9388ba2d8eaa11c273229fa3/pkg/sitewise/client/client.go#L79

Since the number is negative, it just ends up always fetching only 1 page of data before returning. Since the expression data source doesn't support paged queries, it would not follow the next token to continue fetching the remaining data.

**Which issue(s) this PR fixes**:

Fixes #202 

**Special notes for your reviewer**:

To test this, it's better to download the drone build of the data source instead of pulling it and running it locally. To test this, you need to make sure there is enough sample data to cause the query to need to be paged (I think it's about 4.5 hours at least if doing a property aggregate query using a 1m resolution).

I changed the max data points/pages from `math.Inf(1)` to `math.MaxInt32`, but let me know if you think there's a better number we should set it to. 