### PR TITLE
Update grafana/aws-sdk-react dependency and prepare v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.10.3
+
+- Update grafana/aws-sdk-react dependency https://github.com/grafana/iot-sitewise-datasource/pull/20
+
 ## v1.10.2
 
 - Fix: Fix scoped variables replacement in assetids such as repeat panels by @ahom https://github.com/grafana/iot-sitewise-datasource/pull/205

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/runtime": "9.2.5",
-    "@grafana/ui": "9.2.5",
-    "@grafana/aws-sdk": "^0.0.37",
-    "@grafana/e2e": "9.2.5",
+    "@grafana/aws-sdk": "0.0.48",
     "@grafana/data": "9.2.5",
+    "@grafana/e2e": "9.2.5",
     "@grafana/e2e-selectors": "9.2.5",
     "@grafana/eslint-config": "^5.1.0",
+    "@grafana/runtime": "9.2.5",
     "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/ui": "9.2.5",
     "@swc/core": "^1.2.144",
     "@swc/helpers": "^0.4.12",
     "@swc/jest": "^0.2.23",
@@ -61,6 +61,9 @@
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "lodash": "latest",
+    "prettier": "^2.5.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "1.56.1",
     "sass-loader": "13.2.0",
@@ -72,10 +75,7 @@
     "typescript": "^4.4.0",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2",
-    "webpack-livereload-plugin": "^3.0.2",
-    "prettier": "^2.5.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "webpack-livereload-plugin": "^3.0.2"
   },
   "resolutions": {
     "rxjs": "6.6.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-sitewise-datasource",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "View IoT Sitewise data in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,10 +1728,20 @@
     ua-parser-js "^1.0.2"
     web-vitals "^2.1.4"
 
-"@grafana/aws-sdk@^0.0.37":
-  version "0.0.37"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.37.tgz#412b8e6b1c24733f12f19b0df77b4ce0d107ace3"
-  integrity sha512-KAESRygY6U5TaGc/CXzLTEI6TEvmlbdOCYIehPjXjnjQnXQh9HVTLosWOptYy3zu5liZXO/+AR/Q4EEPOwC56w==
+"@grafana/async-query-data@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.4.tgz#ac24e32822a8032dd1ee10ce7dcb8c2e276c58b0"
+  integrity sha512-3d7fm2sf5x/+JKTt4T6MSS/veB2J/YGfQp5Ck0Tbqtc5YIoI0p1JY+vFWfCstEHyVd1H0Ep/q/VSxf4VAs9YKQ==
+  dependencies:
+    tslib "^2.4.1"
+
+"@grafana/aws-sdk@0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.48.tgz#8831b7dc21d4b338b324a22bcaaccde116cd28bb"
+  integrity sha512-lh6aWRoHw0wlkFKY2Qhb3du6iElA2oOtwsMuTmr3urZPTfMhJEzCPkiA/pWYzZHmKaIeez/EYECirQ16k7pW/w==
+  dependencies:
+    "@grafana/async-query-data" "0.1.4"
+    "@grafana/experimental" "1.1.0"
 
 "@grafana/data@9.2.5":
   version "9.2.5"
@@ -1811,6 +1821,14 @@
     eslint-plugin-react "7.31.10"
     eslint-plugin-react-hooks "4.6.0"
     typescript "4.8.4"
+
+"@grafana/experimental@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.1.0.tgz#36b9644b1e61c782ed42b4805c5e297f2cc3f8bf"
+  integrity sha512-pQhYhw+jB7Q+t8rLcd1jcx91BiFDNslBATJkNIgO9I2Bah+ww+2RH1hUGVoJNPL84vW7WRU7w9k/L7FJs7/L6Q==
+  dependencies:
+    "@types/uuid" "^8.3.3"
+    uuid "^8.3.2"
 
 "@grafana/runtime@9.2.5":
   version "9.2.5"
@@ -3173,6 +3191,11 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+
+"@types/uuid@^8.3.3":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -10195,6 +10218,11 @@ tslib@^2.1.0, tslib@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tslib@^2.4.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
+  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
While testing sandboxing, I got errors related to use of grafanaBootData in Sitewise version of aws-sdk. The package has previously been updated to use config instead of grafanaBootData, so this is just to update the dependency to contain the new code.