### PR TITLE
Disassociated streams: Hash entryId to fix bug with property aliases longer than 64 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.12.1
+- Disassociated streams: Hash entryId to fix bug with property aliases longer than 64 characters in [#239](https://github.com/grafana/iot-sitewise-datasource/pull/239)
+
 ## v1.12.0
 - Query by property alias: Add support for unassociated streams in [#231](https://github.com/grafana/iot-sitewise-datasource/pull/231)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-sitewise-datasource",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "View IoT Sitewise data in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/resource/query_resouce_provider.go
+++ b/pkg/resource/query_resouce_provider.go
@@ -59,7 +59,7 @@ func (rp *queryResourceProvider) Properties(ctx context.Context) (map[string]*io
 	properties := map[string]*iotsitewise.DescribeAssetPropertyOutput{}
 	// if the query for a PropertyAlias doesn't have an assetId or propertyId, it means it's a disassociated stream
 	// in that case, we call Property() with empty values, which will set AssetProperty.Name to the alias
-	// and will set the EntryId to the alias (to access values in results)
+	// and will set the EntryId to the hashed alias (to access values in results)
 	if len(rp.baseQuery.AssetIds) == 0 && rp.baseQuery.PropertyId == "" && rp.baseQuery.PropertyAlias != "" {
 		prop, err := rp.resources.Property(ctx, "", "", rp.baseQuery.PropertyAlias)
 		if err != nil {

--- a/pkg/server/test/property_value_aggregate_test.go
+++ b/pkg/server/test/property_value_aggregate_test.go
@@ -229,7 +229,7 @@ func TestPropertyValueAggregateWithDisassociatedStream(t *testing.T) {
 			mock.Anything,
 			mock.MatchedBy(func(input *iotsitewise.BatchGetAssetPropertyAggregatesInput) bool {
 				entries := *input.Entries[0]
-				return *entries.EntryId == "_amazon_renton_1_rpm" &&
+				return *entries.EntryId == "61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef" &&
 					*entries.PropertyAlias == "/amazon/renton/1/rpm" &&
 					*entries.AggregateTypes[0] == "SUM"
 
@@ -243,7 +243,7 @@ func TestPropertyValueAggregateWithDisassociatedStream(t *testing.T) {
 					Timestamp: Pointer(time.Date(2021, 2, 1, 16, 27, 0, 0, time.UTC)),
 					Value:     &iotsitewise.Aggregates{Sum: Pointer(1688.6)},
 				}},
-				EntryId: aws.String("_amazon_renton_1_rpm"),
+				EntryId: aws.String("61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef"),
 			}},
 		}, nil)
 

--- a/pkg/server/test/property_value_test.go
+++ b/pkg/server/test/property_value_test.go
@@ -211,7 +211,7 @@ func Test_property_value_query_by_alias_disassociated_stream(t *testing.T) {
 					DoubleValue: Pointer(float64(23.8)),
 				},
 			},
-			EntryId: Pointer("_amazon_renton_1_rpm"),
+			EntryId: Pointer("61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef"),
 		}}}, nil)
 
 	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
@@ -260,7 +260,7 @@ func Test_property_value_query_by_alias_disassociated_stream(t *testing.T) {
 		mock.Anything,
 		&iotsitewise.BatchGetAssetPropertyValueInput{
 			Entries: []*iotsitewise.BatchGetAssetPropertyValueEntry{{
-				EntryId:       Pointer("_amazon_renton_1_rpm"),
+				EntryId:       Pointer("61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef"),
 				PropertyAlias: Pointer("/amazon/renton/1/rpm"),
 			}},
 		},

--- a/pkg/testdata/property-history-values-boolean-disassociated-empty-response.json
+++ b/pkg/testdata/property-history-values-boolean-disassociated-empty-response.json
@@ -2,7 +2,7 @@
   "SuccessEntries": [
     {
       "AssetPropertyValueHistory": [],
-      "EntryId": "_amazon_renton_1_rpm"
+      "EntryId": "61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef"
     }
   ],
   "NextToken": null

--- a/pkg/testdata/property-history-values-boolean-disassociated.json
+++ b/pkg/testdata/property-history-values-boolean-disassociated.json
@@ -458,7 +458,7 @@
           }
         }
       ],
-      "EntryId": "_amazon_renton_1_rpm"
+      "EntryId": "61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef"
     }
   ],
   "NextToken": null

--- a/pkg/testdata/property-value-disassociated.json
+++ b/pkg/testdata/property-value-disassociated.json
@@ -14,7 +14,7 @@
           "StringValue": null
         }
       },
-      "EntryId": "_amazon_renton_1_rpm"
+      "EntryId": "61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef"
     }
   ],
   "NextToken": null


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
When implementing disassociated data streams, I set the entryID to be equal to the propertyAlias. Normally for associated streams it is set to assetID. This isn't possible for disassociated streams since they don't have an asset connected to them. 
However, I didn't account for property aliases that are longer than 64 characters. 
One possible solution is to hash the property aliases. As far as I can see, they don't need to be in human readable format, since entryId is used on our BE to:
1. send along with queries to distinguish them and
2. access the results of those queries, be they success or errors, and append them to our frames. 

The names of the frames/fields don't come from entryIDs but from the property aliases from the query, which are readable. 

Another solution would be to just shorten the string, but it is possible to have 2 property aliases that are almost the same apart from the end. This would create two equal entryIDs, so I didn't go with this approach.

**Which issue(s) this PR fixes**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/iot-sitewise-datasource/issues/237

**Special notes for your reviewer**: