### PR TITLE
Property aggregate processing: Move out ErrorEntries processing from SuccessEntries block

### DIFF
--- a/pkg/framer/property_aggregate.go
+++ b/pkg/framer/property_aggregate.go
@@ -109,21 +109,19 @@ func (a AssetPropertyAggregates) Frames(ctx context.Context, resources resource.
 				Aggregates: aws.StringValueSlice(a.Request.Entries[i].AggregateTypes),
 			},
 		}
-
-		for _, e := range resp.ErrorEntries {
-			property := properties[*e.EntryId]
-			frame := data.NewFrame(getFrameName(property))
-			if e.ErrorMessage != nil {
-				frame.Meta = &data.FrameMeta{
-					Notices: []data.Notice{{Severity: data.NoticeSeverityError, Text: *e.ErrorMessage}},
-				}
-			}
-			frames = append(frames, frame)
-		}
-
 		frames = append(frames, frame)
 	}
 
+	for _, e := range resp.ErrorEntries {
+		property := properties[*e.EntryId]
+		frame := data.NewFrame(getFrameName(property))
+		if e.ErrorMessage != nil {
+			frame.Meta = &data.FrameMeta{
+				Notices: []data.Notice{{Severity: data.NoticeSeverityError, Text: *e.ErrorMessage}},
+			}
+		}
+		frames = append(frames, frame)
+	}
 	return frames, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
I noticed that the ErrorEntries block in property_aggregates.go was inside the SuccessEntries block. I don't think it should be there because
1. This is not the case with other response processing types, [for example](https://github.com/grafana/iot-sitewise-datasource/blob/main/pkg/framer/property_value.go#L23)
2. Sitewise API reference doesn't contain anything that would suggest error entries would only be present if success entries are: https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchGetAssetPropertyAggregates.html (the response structure is the same as other BatchGetAsset* endpoints)

I moved it out so it mimics the other response processing functions.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: