### PR TITLE
Support multiple assets for interpolated queries

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -59,6 +59,9 @@
     "httptrace",
     "otelhttptrace",
     "idastambuk",
-    "fridgepoet"
+    "fridgepoet",
+    "errgroup",
+    "ectx",
+    "reqs"
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.5.0
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -585,6 +585,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/framer/property_interpolated.go
+++ b/pkg/framer/property_interpolated.go
@@ -9,38 +9,69 @@ import (
 	"github.com/grafana/iot-sitewise-datasource/pkg/framer/fields"
 	"github.com/grafana/iot-sitewise-datasource/pkg/models"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/resource"
+	"github.com/grafana/iot-sitewise-datasource/pkg/util"
 )
 
 type InterpolatedAssetPropertyValue struct {
-	*iotsitewise.GetInterpolatedAssetPropertyValuesOutput
-	Query models.AssetPropertyValueQuery
+	Responses map[string]*iotsitewise.GetInterpolatedAssetPropertyValuesOutput
+	Query     models.AssetPropertyValueQuery
 }
 
 func (p InterpolatedAssetPropertyValue) Frames(ctx context.Context, resources resource.ResourceProvider) (data.Frames, error) {
-	property, err := resources.Property(ctx)
+	properties, err := resources.Properties(ctx)
+
 	if err != nil {
 		return nil, err
 	}
 
+	frames := data.Frames{}
+
+	for entryId, res := range p.Responses {
+		property := properties[entryId]
+		if property == nil {
+			property = properties[*util.GetEntryId(p.Query.BaseQuery)]
+		}
+		frame, err := p.Frame(ctx, property, res.InterpolatedAssetPropertyValues)
+		if err != nil {
+			return nil, err
+		}
+
+		frames = append(frames, frame)
+	}
+
+	return frames, nil
+}
+
+func (p InterpolatedAssetPropertyValue) Frame(ctx context.Context, property *iotsitewise.DescribeAssetPropertyOutput, v []*iotsitewise.InterpolatedAssetPropertyValue) (*data.Frame, error) {
 	// TODO: make this work with the API instead of ad-hoc dataType inference
 	// https://github.com/grafana/iot-sitewise-datasource/issues/98#issuecomment-892947756
 	if *property.AssetProperty.DataType == *aws.String("?") {
-		property.AssetProperty.DataType = aws.String(getPropertyVariantValueType(p.InterpolatedAssetPropertyValues[0].Value))
+		property.AssetProperty.DataType = aws.String(getPropertyVariantValueType(v[0].Value))
 	}
 
 	timeField := fields.TimeField(0)
 	valueField := fields.PropertyValueFieldForQuery(p.Query, property, 0)
+	name := *property.AssetName
+	if name == "" {
+		name = *property.AssetProperty.Name
+	}
+	frame := data.NewFrame(name, timeField, valueField)
 
-	frame := data.NewFrame(*property.AssetName, timeField, valueField)
-
+	entryId := ""
+	if property.AssetId != nil {
+		entryId = *property.AssetId
+	} else {
+		entryId = *property.AssetProperty.Name
+	}
 	frame.Meta = &data.FrameMeta{
 		Custom: models.SitewiseCustomMeta{
-			NextToken:  aws.StringValue(p.NextToken),
+			NextToken:  aws.StringValue(p.Responses[entryId].NextToken),
+			EntryId:    entryId,
 			Resolution: p.Query.Resolution,
 		},
 	}
 
-	for _, v := range p.InterpolatedAssetPropertyValues {
+	for _, v := range v {
 		value := getPropertyVariantValue(v.Value)
 		if value == nil {
 			continue
@@ -49,5 +80,5 @@ func (p InterpolatedAssetPropertyValue) Frames(ctx context.Context, resources re
 		valueField.Append(value)
 	}
 
-	return data.Frames{frame}, nil
+	return frame, nil
 }

--- a/pkg/models/meta.go
+++ b/pkg/models/meta.go
@@ -3,6 +3,7 @@ package models
 // SitewiseCustomMeta is the standard metadata
 type SitewiseCustomMeta struct {
 	NextToken  string   `json:"nextToken,omitempty"`
+	EntryId    string   `json:"entryId,omitempty"`
 	Resolution string   `json:"resolution,omitempty"`
 	Aggregates []string `json:"aggregates,omitempty"`
 }

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -30,13 +30,14 @@ const (
 type BaseQuery struct {
 	AwsRegion string `json:"region,omitempty"`
 	// Deprecated: use assetIds
-	AssetId             string   `json:"assetId,omitempty"`
-	AssetIds            []string `json:"assetIds,omitempty"`
-	PropertyId          string   `json:"propertyId,omitempty"`
-	PropertyAlias       string   `json:"propertyAlias,omitempty"`
-	NextToken           string   `json:"nextToken,omitempty"`
-	MaxPageAggregations int      `json:"maxPageAggregations,omitempty"`
-	ResponseFormat      string   `json:"responseFormat,omitempty"`
+	AssetId             string            `json:"assetId,omitempty"`
+	AssetIds            []string          `json:"assetIds,omitempty"`
+	PropertyId          string            `json:"propertyId,omitempty"`
+	PropertyAlias       string            `json:"propertyAlias,omitempty"`
+	NextToken           string            `json:"nextToken,omitempty"`
+	NextTokens          map[string]string `json:"nextTokens,omitempty"`
+	MaxPageAggregations int               `json:"maxPageAggregations,omitempty"`
+	ResponseFormat      string            `json:"responseFormat,omitempty"`
 
 	Interval      time.Duration     `json:"-"`
 	TimeRange     backend.TimeRange `json:"-"`

--- a/pkg/server/test/property_value_interpolated_test.go
+++ b/pkg/server/test/property_value_interpolated_test.go
@@ -1,0 +1,235 @@
+package test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iotsitewise"
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/iot-sitewise-datasource/pkg/models"
+	"github.com/grafana/iot-sitewise-datasource/pkg/server"
+	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise"
+	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client/mocks"
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPropertyValueInterpolatedQuery(t *testing.T) {
+	mockSw := &mocks.SitewiseClient{}
+
+	mockSw.On(
+		"GetInterpolatedAssetPropertyValuesPageAggregation",
+		mock.Anything,
+		mock.MatchedBy(func(input *iotsitewise.GetInterpolatedAssetPropertyValuesInput) bool {
+			return *input.AssetId == "1assetid-aaaa-2222-bbbb-3333cccc4444"
+		}),
+		mock.Anything,
+		mock.Anything,
+	).Return(&iotsitewise.GetInterpolatedAssetPropertyValuesOutput{
+		NextToken: Pointer("asset1-next-token"),
+		InterpolatedAssetPropertyValues: []*iotsitewise.InterpolatedAssetPropertyValue{
+			{
+				Timestamp: &iotsitewise.TimeInNanos{
+					OffsetInNanos: Pointer(int64(0)),
+					TimeInSeconds: Pointer(int64(1612207100)),
+				},
+				Value: &iotsitewise.Variant{
+					DoubleValue: Pointer(1.1),
+				},
+			},
+		},
+	}, nil)
+
+	mockSw.On(
+		"GetInterpolatedAssetPropertyValuesPageAggregation",
+		mock.Anything,
+		mock.MatchedBy(func(input *iotsitewise.GetInterpolatedAssetPropertyValuesInput) bool {
+			return *input.AssetId == "2assetid-aaaa-2222-bbbb-3333cccc4444"
+		}),
+		mock.Anything,
+		mock.Anything,
+	).Return(&iotsitewise.GetInterpolatedAssetPropertyValuesOutput{
+		NextToken: Pointer("asset2-next-token"),
+		InterpolatedAssetPropertyValues: []*iotsitewise.InterpolatedAssetPropertyValue{
+			{
+				Timestamp: &iotsitewise.TimeInNanos{
+					OffsetInNanos: Pointer(int64(0)),
+					TimeInSeconds: Pointer(int64(1612207200)),
+				},
+				Value: &iotsitewise.Variant{
+					DoubleValue: Pointer(2.2),
+				},
+			},
+		},
+	}, nil)
+
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, &iotsitewise.DescribeAssetPropertyInput{
+		AssetId:    aws.String("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+		PropertyId: aws.String("11propid-aaaa-2222-bbbb-3333cccc4444"),
+	}, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
+		AssetId:   Pointer("1assetid-aaaa-2222-bbbb-3333cccc4444"),
+		AssetName: Pointer("Demo Turbine Asset 1"),
+		AssetProperty: &iotsitewise.Property{
+			DataType: Pointer("DOUBLE"),
+			Name:     Pointer("Wind Speed"),
+			Unit:     Pointer("m/s"),
+		},
+	}, nil)
+
+	mockSw.On("DescribeAssetPropertyWithContext", mock.Anything, &iotsitewise.DescribeAssetPropertyInput{
+		AssetId:    aws.String("2assetid-aaaa-2222-bbbb-3333cccc4444"),
+		PropertyId: aws.String("11propid-aaaa-2222-bbbb-3333cccc4444"),
+	}, mock.Anything).Return(&iotsitewise.DescribeAssetPropertyOutput{
+		AssetId:   Pointer("2assetid-aaaa-2222-bbbb-3333cccc4444"),
+		AssetName: Pointer("Demo Turbine Asset 2"),
+		AssetProperty: &iotsitewise.Property{
+			DataType: Pointer("DOUBLE"),
+			Name:     Pointer("Wind Speed"),
+			Unit:     Pointer("m/s"),
+		},
+	}, nil)
+
+	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	query := &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				RefID:     "A",
+				QueryType: models.QueryTypePropertyInterpolated,
+				TimeRange: timeRange,
+				JSON: []byte(`{
+					"assetIds": ["1assetid-aaaa-2222-bbbb-3333cccc4444", "2assetid-aaaa-2222-bbbb-3333cccc4444"],
+					"propertyId": "11propid-aaaa-2222-bbbb-3333cccc4444",
+					"resolution": "1m"
+				}`),
+			},
+		},
+	}
+
+	qdr, err := srvr.HandleInterpolatedPropertyValue(context.Background(), query)
+	require.Nil(t, err)
+	_, ok := qdr.Responses["A"]
+	require.True(t, ok)
+	require.Equal(t, 2, len(qdr.Responses["A"].Frames))
+	require.NotNil(t, qdr.Responses["A"].Frames[0])
+	require.NotNil(t, qdr.Responses["A"].Frames[1])
+
+	sort.Slice(qdr.Responses["A"].Frames, func(a, b int) bool {
+		return qdr.Responses["A"].Frames[a].Name < qdr.Responses["A"].Frames[b].Name
+	})
+
+	expectedFrames := data.Frames{
+		data.NewFrame("Demo Turbine Asset 1",
+			data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 19, 18, 20, 0, time.UTC)}),
+			data.NewField("Wind Speed", nil, []float64{1.1}).SetConfig(&data.FieldConfig{Unit: "m/s"}),
+		).SetMeta(&data.FrameMeta{
+			Custom: models.SitewiseCustomMeta{
+				NextToken:  "asset1-next-token",
+				EntryId:    "1assetid-aaaa-2222-bbbb-3333cccc4444",
+				Resolution: "1m",
+				Aggregates: []string{},
+			},
+		}),
+		data.NewFrame("Demo Turbine Asset 2",
+			data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 19, 20, 0, 0, time.UTC)}),
+			data.NewField("Wind Speed", nil, []float64{2.2}).SetConfig(&data.FieldConfig{Unit: "m/s"}),
+		).SetMeta(&data.FrameMeta{
+			Custom: models.SitewiseCustomMeta{
+				NextToken:  "asset2-next-token",
+				EntryId:    "2assetid-aaaa-2222-bbbb-3333cccc4444",
+				Resolution: "1m",
+				Aggregates: []string{},
+			},
+		}),
+	}
+
+	if diff := cmp.Diff(expectedFrames, qdr.Responses["A"].Frames, data.FrameTestCompareOptions()...); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+	}
+
+	mockSw.AssertExpectations(t)
+}
+
+func TestPropertyValueInterpolatedQueryWithPropertyAlias(t *testing.T) {
+	mockSw := &mocks.SitewiseClient{}
+
+	mockSw.On(
+		"GetInterpolatedAssetPropertyValuesPageAggregation",
+		mock.Anything,
+		mock.MatchedBy(func(input *iotsitewise.GetInterpolatedAssetPropertyValuesInput) bool {
+			return *input.PropertyAlias == "/turbine_1/wind_speed"
+		}),
+		mock.Anything,
+		mock.Anything,
+	).Return(&iotsitewise.GetInterpolatedAssetPropertyValuesOutput{
+		NextToken: Pointer("asset1-next-token"),
+		InterpolatedAssetPropertyValues: []*iotsitewise.InterpolatedAssetPropertyValue{
+			{
+				Timestamp: &iotsitewise.TimeInNanos{
+					OffsetInNanos: Pointer(int64(0)),
+					TimeInSeconds: Pointer(int64(1612207100)),
+				},
+				Value: &iotsitewise.Variant{
+					DoubleValue: Pointer(1.1),
+				},
+			},
+		},
+	}, nil)
+
+	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	query := &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				RefID:     "A",
+				QueryType: models.QueryTypePropertyInterpolated,
+				TimeRange: timeRange,
+				JSON: []byte(`{
+					"propertyAlias": "/turbine_1/wind_speed",
+					"resolution": "1m"
+				}`),
+			},
+		},
+	}
+
+	qdr, err := srvr.HandleInterpolatedPropertyValue(context.Background(), query)
+	require.Nil(t, err)
+	_, ok := qdr.Responses["A"]
+	require.True(t, ok)
+	require.Equal(t, 1, len(qdr.Responses["A"].Frames))
+	require.NotNil(t, qdr.Responses["A"].Frames[0])
+
+	expectedFrames := data.Frames{
+		data.NewFrame("/turbine_1/wind_speed",
+			data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 19, 18, 20, 0, time.UTC)}),
+			data.NewField("/turbine_1/wind_speed", nil, []float64{1.1}).SetConfig(&data.FieldConfig{}),
+		).SetMeta(&data.FrameMeta{
+			Custom: models.SitewiseCustomMeta{
+				NextToken:  "asset1-next-token",
+				EntryId:    "/turbine_1/wind_speed",
+				Resolution: "1m",
+				Aggregates: []string{},
+			},
+		}),
+	}
+
+	if diff := cmp.Diff(expectedFrames, qdr.Responses["A"].Frames, data.FrameTestCompareOptions()...); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+	}
+
+	mockSw.AssertExpectations(t)
+}

--- a/pkg/sitewise/api/property_interpolated.go
+++ b/pkg/sitewise/api/property_interpolated.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/api/propvals"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client"
 	"github.com/grafana/iot-sitewise-datasource/pkg/util"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -17,7 +18,12 @@ var (
 	LINEAR_INTERPOLATION string = "LINEAR_INTERPOLATION"
 )
 
-func interpolatedQueryToInput(query models.AssetPropertyValueQuery) *iotsitewise.GetInterpolatedAssetPropertyValuesInput {
+type responseWrapper struct {
+	DataResponse *iotsitewise.GetInterpolatedAssetPropertyValuesOutput
+	EntryId      string
+}
+
+func interpolatedQueryToInputs(query models.AssetPropertyValueQuery) []*iotsitewise.GetInterpolatedAssetPropertyValuesInput {
 	//if propertyAlias is set make sure to set the assetId and propertyId to nil
 	if query.PropertyAlias != "" {
 		query.PropertyId = ""
@@ -50,31 +56,96 @@ func interpolatedQueryToInput(query models.AssetPropertyValueQuery) *iotsitewise
 		intervalInSeconds = 1
 	}
 
-	return &iotsitewise.GetInterpolatedAssetPropertyValuesInput{
-		StartTimeInSeconds: &startTimeInSeconds,
-		EndTimeInSeconds:   &endTimeInSeconds,
-		IntervalInSeconds:  aws.Int64(intervalInSeconds),
-		MaxResults:         aws.Int64(10),
-		NextToken:          getNextToken(query.BaseQuery),
-		AssetId:            util.GetAssetId(query.BaseQuery),
-		PropertyId:         util.GetPropertyId(query.BaseQuery),
-		PropertyAlias:      util.GetPropertyAlias(query.BaseQuery),
-		Quality:            &quality,
-		Type:               &interpolationType,
+	awsReqsLen := len(query.AssetIds)
+	if query.PropertyAlias != "" {
+		awsReqsLen = 1
 	}
+	awsReqs := make([]*iotsitewise.GetInterpolatedAssetPropertyValuesInput, awsReqsLen)
+	if query.PropertyAlias != "" {
+		var nextToken *string
+		token, ok := query.NextTokens[query.PropertyAlias]
+		if ok {
+			nextToken = aws.String(token)
+		}
+		awsReqs[0] = &iotsitewise.GetInterpolatedAssetPropertyValuesInput{
+			StartTimeInSeconds: &startTimeInSeconds,
+			EndTimeInSeconds:   &endTimeInSeconds,
+			IntervalInSeconds:  aws.Int64(intervalInSeconds),
+			MaxResults:         aws.Int64(10),
+			NextToken:          nextToken,
+			AssetId:            util.GetAssetId(query.BaseQuery),
+			PropertyId:         util.GetPropertyId(query.BaseQuery),
+			PropertyAlias:      util.GetPropertyAlias(query.BaseQuery),
+			Quality:            &quality,
+			Type:               &interpolationType,
+		}
+		return awsReqs
+	} else {
+		for idx, assetId := range query.AssetIds {
+			var nextToken *string
+			token, ok := query.NextTokens[assetId]
+			if ok {
+				nextToken = aws.String(token)
+			}
+			awsReqs[idx] = &iotsitewise.GetInterpolatedAssetPropertyValuesInput{
+				StartTimeInSeconds: &startTimeInSeconds,
+				EndTimeInSeconds:   &endTimeInSeconds,
+				IntervalInSeconds:  aws.Int64(intervalInSeconds),
+				MaxResults:         aws.Int64(10),
+				NextToken:          nextToken,
+				AssetId:            aws.String(assetId),
+				PropertyId:         util.GetPropertyId(query.BaseQuery),
+				PropertyAlias:      util.GetPropertyAlias(query.BaseQuery),
+				Quality:            &quality,
+				Type:               &interpolationType,
+			}
+		}
+	}
+
+	return awsReqs
 }
 
 func GetInterpolatedAssetPropertyValues(ctx context.Context, client client.SitewiseClient, query models.AssetPropertyValueQuery) (*framer.InterpolatedAssetPropertyValue, error) {
 	maxDps := int(query.MaxDataPoints)
-	awsReq := interpolatedQueryToInput(query)
+	awsReqs := interpolatedQueryToInputs(query)
 
-	resp, err := client.GetInterpolatedAssetPropertyValuesPageAggregation(ctx, awsReq, query.MaxPageAggregations, maxDps)
+	resultChan := make(chan *responseWrapper, len(awsReqs))
+	eg, ectx := errgroup.WithContext(ctx)
+	for _, req := range awsReqs {
+		awsReq := req
+		eg.Go(func() error {
+			resp, err := client.GetInterpolatedAssetPropertyValuesPageAggregation(ectx, awsReq, query.MaxPageAggregations, maxDps)
+			if err != nil {
+				return err
+			}
+			entryId := ""
+			if awsReq.AssetId != nil {
+				entryId = *awsReq.AssetId
+			} else {
+				entryId = *awsReq.PropertyAlias
+			}
+			resultChan <- &responseWrapper{
+				DataResponse: resp,
+				EntryId:      entryId,
+			}
+
+			return nil
+		})
+	}
+
+	err := eg.Wait()
+	close(resultChan)
 	if err != nil {
 		return nil, err
 	}
 
+	responses := make(map[string]*iotsitewise.GetInterpolatedAssetPropertyValuesOutput, len(awsReqs))
+	for result := range resultChan {
+		responses[result.EntryId] = result.DataResponse
+	}
+
 	return &framer.InterpolatedAssetPropertyValue{
-		GetInterpolatedAssetPropertyValuesOutput: resp,
-		Query:                                    query,
+		Responses: responses,
+		Query:     query,
 	}, nil
 }

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -112,8 +112,8 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
         } else {
           txt += ' / ' + query.propertyId;
         }
-      } 
-    } else if(query.propertyAlias) {
+      }
+    } else if (query.propertyAlias) {
       txt += ' / ' + query.propertyAlias;
     }
     return txt;
@@ -129,9 +129,7 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
       propertyAlias: templateSrv.replace(query.propertyAlias, scopedVars),
       region: templateSrv.replace(query.region || '', scopedVars),
       propertyId: templateSrv.replace(query.propertyId || '', scopedVars),
-      assetIds: query.assetIds?.flatMap(
-        assetId => templateSrv.replace(assetId, scopedVars, 'csv').split(',')
-      ) ?? []
+      assetIds: query.assetIds?.flatMap((assetId) => templateSrv.replace(assetId, scopedVars, 'csv').split(',')) ?? [],
     };
   }
 
@@ -151,10 +149,21 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
             if (meta && meta.nextToken) {
               const query = request.targets.find((t) => t.refId === frame.refId);
               if (query) {
-                next.push({
-                  ...query,
-                  nextToken: meta.nextToken,
-                });
+                const existingNextQuery = next.find((v) => v.refId === frame.refId);
+                if (existingNextQuery) {
+                  if (existingNextQuery.nextToken !== meta.nextToken && meta.entryId && meta.nextToken) {
+                    if (!existingNextQuery.nextTokens) {
+                      existingNextQuery.nextTokens = {};
+                    }
+                    existingNextQuery.nextTokens[meta.entryId] = meta.nextToken;
+                  }
+                } else {
+                  next.push({
+                    ...query,
+                    nextToken: meta.nextToken,
+                    nextTokens: { ...(meta.entryId && meta.nextToken ? { [meta.entryId]: meta.nextToken } : {}) },
+                  });
+                }
               }
             }
           }

--- a/src/appendFrames.ts
+++ b/src/appendFrames.ts
@@ -1,7 +1,7 @@
 import { ArrayVector, DataFrame, formatLabels, MutableDataFrame } from '@grafana/data';
 
 export function getSchemaKey(frame: DataFrame): string {
-  let key = frame.refId + '/' + frame.fields.length;
+  let key = frame.refId + '/' + frame.fields.length + '/' + frame.name;
   for (const f of frame.fields) {
     key += '|' + f.name + ':' + f.type;
     if (f.labels) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface SitewiseNextQuery extends SitewiseQuery {
    * will require multiple pages in order to fulfil the requests
    */
   nextToken?: string;
+  nextTokens?: Record<string, string>;
 }
 
 /**
@@ -224,6 +225,8 @@ export interface AssetInfo {
  */
 export interface SitewiseCustomMeta {
   nextToken?: string;
+
+  entryId?: string;
 
   resolution?: string;
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

It allows selecting multiple assets when using an interpolated property values query.

Before:
<img width="1696" alt="before" src="https://github.com/grafana/iot-sitewise-datasource/assets/19530599/d8eafff2-627f-4e03-809e-b0c9678d1108">

After:
<img width="1696" alt="after" src="https://github.com/grafana/iot-sitewise-datasource/assets/19530599/2ecad758-559c-4750-8ec8-ddea989764dc">

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #235 

**Special notes for your reviewer**:

- As a part of this another bug was fixed where when multiple assets were selected and the property values history query was selected, and the time range was long enough where a multiple queries were needed to fetch all of the data points, it would error

Before:
<img width="1696" alt="2-before" src="https://github.com/grafana/iot-sitewise-datasource/assets/19530599/784eb5de-e9a9-46e0-be7e-2d4b8917cbeb">

After:
<img width="1696" alt="2-after" src="https://github.com/grafana/iot-sitewise-datasource/assets/19530599/c35937cb-f6af-461f-aeff-f39684ad7406">


See the screenshots for the queries used for testing. Demo assets may need to be recreated in the external dev account if it expires.