### PR TITLE
Use query region to get client for queries

### DIFF
--- a/pkg/sitewise/client/client.go
+++ b/pkg/sitewise/client/client.go
@@ -168,7 +168,9 @@ func (c *sitewiseClient) BatchGetAssetPropertyAggregatesPageAggregation(ctx cont
 type AmazonSessionProvider func(c awsds.SessionConfig) (*session.Session, error)
 
 func GetClient(region string, settings models.AWSSiteWiseDataSourceSetting, provider AmazonSessionProvider) (client SitewiseClient, err error) {
-	sess, err := provider(awsds.SessionConfig{Settings: settings.ToAWSDatasourceSettings()})
+	awsSettings := settings.ToAWSDatasourceSettings()
+	awsSettings.Region = region
+	sess, err := provider(awsds.SessionConfig{Settings: awsSettings})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
We weren't using the region from the query to get the client, despite sending it. This PR uses the region in the config sent to the SessionCache.

As a side note it feels like we have a lot of unnecessary abstraction in the sitewise plugin.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #250 

**Special notes for your reviewer**: