### PR TITLE
feat: implement all option for list associated assets query

### DIFF
--- a/pkg/models/asset.go
+++ b/pkg/models/asset.go
@@ -23,6 +23,7 @@ type ListAssetsQuery struct {
 type ListAssociatedAssetsQuery struct {
 	BaseQuery
 	HierarchyId string `json:"hierarchyId,omitempty"`
+	LoadAllChildren bool `json:"loadAllChildren,omitempty"`
 	// TraversalDirection is implied from the existence of HierarchyId
 }
 

--- a/pkg/sitewise/api/list_associated_assets.go
+++ b/pkg/sitewise/api/list_associated_assets.go
@@ -17,29 +17,73 @@ func ListAssociatedAssets(ctx context.Context, client client.SitewiseClient, que
 	var (
 		hierarchyId        *string
 		traversalDirection *string
+		assetId            *string = util.GetAssetId(query.BaseQuery)
+		results            []*iotsitewise.AssociatedAssetsSummary
 	)
 
-	if query.HierarchyId != "" {
-		hierarchyId = aws.String(query.HierarchyId)
-		traversalDirection = aws.String("CHILD")
+	// Recursively load children
+	if query.LoadAllChildren {
+		asset, err := client.DescribeAsset(&iotsitewise.DescribeAssetInput{
+			AssetId: assetId,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, h := range asset.AssetHierarchies {
+			// For this code path, we need to handle this internally, since it's a union of multiple queries
+			var nextToken *string = nil
+
+			for {
+				resp, err := client.ListAssociatedAssetsWithContext(ctx, &iotsitewise.ListAssociatedAssetsInput{
+					AssetId:     assetId,
+					HierarchyId: h.Id,
+					MaxResults:  MaxSitewiseResults,
+					NextToken:   nextToken,
+				})
+
+				if err != nil {
+					return nil, err
+				}
+
+				results = append(results, resp.AssetSummaries...)
+
+				if resp.NextToken == nil {
+					break
+				}
+
+				nextToken = resp.NextToken
+			}
+		}
+
+		return &framer.AssociatedAssets{
+			AssetSummaries: results,
+		}, nil
+
 	} else {
-		traversalDirection = aws.String("PARENT")
+		if query.HierarchyId != "" {
+			hierarchyId = aws.String(query.HierarchyId)
+			traversalDirection = aws.String("CHILD")
+		} else {
+			traversalDirection = aws.String("PARENT")
+		}
+
+		resp, err := client.ListAssociatedAssetsWithContext(ctx, &iotsitewise.ListAssociatedAssetsInput{
+			AssetId:            assetId,
+			HierarchyId:        hierarchyId,
+			MaxResults:         MaxSitewiseResults,
+			NextToken:          getNextToken(query.BaseQuery),
+			TraversalDirection: traversalDirection,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		return &framer.AssociatedAssets{
+			AssetSummaries: resp.AssetSummaries,
+			NextToken:      resp.NextToken,
+		}, nil
 	}
-
-	resp, err := client.ListAssociatedAssetsWithContext(ctx, &iotsitewise.ListAssociatedAssetsInput{
-		AssetId:            util.GetAssetId(query.BaseQuery),
-		HierarchyId:        hierarchyId,
-		MaxResults:         MaxSitewiseResults,
-		NextToken:          getNextToken(query.BaseQuery),
-		TraversalDirection: traversalDirection,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &framer.AssociatedAssets{
-		AssetSummaries: resp.AssetSummaries,
-		NextToken:      resp.NextToken,
-	}, nil
 }

--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -59,6 +59,8 @@ interface State {
   openModal: boolean;
 }
 
+const ALL_HIERARCHIES = '*';
+
 export class PropertyQueryEditor extends PureComponent<Props, State> {
   state: State = {
     assets: [],
@@ -176,10 +178,15 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
     const { onChange, query, onRunQuery } = this.props;
     const update = { ...query };
     if (isListAssociatedAssetsQuery(update)) {
-      if (sel.value && sel.value.length) {
+      if (sel.value === ALL_HIERARCHIES) {
+        delete update.hierarchyId;
+        update.loadAllChildren = true;
+      } else if (sel.value && sel.value.length) {
         update.hierarchyId = sel.value;
+        update.loadAllChildren = false;
       } else {
         delete update.hierarchyId;
+        update.loadAllChildren = false;
       }
     }
     onChange(update);
@@ -257,7 +264,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
 
   renderAssociatedAsset(query: ListAssociatedAssetsQuery) {
     const { asset, loading } = this.state;
-    const hierarchies: Array<SelectableValue<string>> = [{ value: '', label: '** Parent **' }];
+    const hierarchies: Array<SelectableValue<string>> = [{ value: '', label: '** Parent **' }, { value: ALL_HIERARCHIES, label: '** All **' }];
     if (asset) {
       hierarchies.push(...asset.hierarchy);
     }
@@ -268,7 +275,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
         current = { value: query.hierarchyId, label: 'ID: ' + query.hierarchyId };
         hierarchies.push(current);
       } else {
-        current = hierarchies[0]; // parent
+        current = query.loadAllChildren ? hierarchies[1] /* all */ : hierarchies[0]; // parent
       }
     }
     return this.props.newFormStylingEnabled ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,8 @@ export function isListAssetsQuery(q?: SitewiseQuery): q is ListAssetsQuery {
 
 export interface ListAssociatedAssetsQuery extends SitewiseQuery {
   queryType: QueryType.ListAssociatedAssets;
-  hierarchyId?: string; // if empty, will list the parents
+  loadAllChildren?: boolean; // When passed, we will loop through all associated hierarchies, and return children from all.
+  hierarchyId?: string; // if empty and loadAllChildren is false, will list the parents
 }
 
 export function isListAssociatedAssetsQuery(q?: SitewiseQuery): q is ListAssociatedAssetsQuery {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
This pull request implements a flag to add an "**ALL**" option to the ListAssociatedAssets query. Listing children in this way currently isn't supported natively by the SiteWise API, so we work around this by first getting all the asset hierarchies, and requesting them individually, and unifying them at the end. This is temporary, as this API change will be added on the SiteWise end next year to improve scalability. It essentially enables the user to setup navigation through their asset hierarchies in the same way as the SiteWise Console Asset explorer does (and this uses the same approach as the console).

**Which issue(s) this PR fixes**:
This is a critical feature request for one of our customers.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: