### PR TITLE
Fix: Infer data type for disassociated streams for property value queries by alias

### DIFF
--- a/pkg/framer/property_value.go
+++ b/pkg/framer/property_value.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/iot-sitewise-datasource/pkg/framer/fields"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iotsitewise"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/resource"
@@ -22,6 +23,9 @@ func (p AssetPropertyValue) Frames(ctx context.Context, resources resource.Resou
 
 	for _, e := range p.SuccessEntries {
 		property := properties[*e.EntryId]
+		if *property.AssetProperty.DataType == *aws.String("?") && e.AssetPropertyValue != nil {
+			property.AssetProperty.DataType = aws.String(getPropertyVariantValueType(e.AssetPropertyValue.Value))
+		}
 		timeField := fields.TimeField(0)
 		valueField := fields.PropertyValueField(property, 0)
 		qualityField := fields.QualityField(0)

--- a/pkg/server/test/property_value_test.go
+++ b/pkg/server/test/property_value_test.go
@@ -271,6 +271,83 @@ func Test_property_value_query_by_alias_disassociated_stream(t *testing.T) {
 		mock.Anything,
 	)
 }
+func Test_property_value_query_by_alias_disassociated_stream_with_integer_value(t *testing.T) {
+	mockSw := &mocks.SitewiseClient{}
+	mockSw.On("DescribeTimeSeriesWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.DescribeTimeSeriesOutput{
+		Alias: Pointer("/amazon/renton/1/rpm"),
+	}, nil)
+	mockSw.On("BatchGetAssetPropertyValueWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.BatchGetAssetPropertyValueOutput{
+		SuccessEntries: []*iotsitewise.BatchGetAssetPropertyValueSuccessEntry{{
+			AssetPropertyValue: &iotsitewise.AssetPropertyValue{
+				Quality: Pointer("GOOD"),
+				Timestamp: &iotsitewise.TimeInNanos{
+					OffsetInNanos: Pointer(int64(0)),
+					TimeInSeconds: Pointer(int64(1612207200)),
+				},
+				Value: &iotsitewise.Variant{
+					IntegerValue: Pointer(int64(23)),
+				},
+			},
+			EntryId: Pointer("61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef"),
+		}}}, nil)
+
+	srvr := &server.Server{Datasource: mockedDatasource(mockSw).(*sitewise.Datasource)}
+
+	sitewise.GetCache = func() *cache.Cache {
+		return cache.New(cache.DefaultExpiration, cache.NoExpiration)
+	}
+
+	qdr, err := srvr.HandlePropertyValue(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				RefID:     "A",
+				QueryType: models.QueryTypePropertyValue,
+				TimeRange: timeRange,
+				JSON: []byte(
+					`{
+					   "region":"us-west-2",
+					   "propertyAlias":"/amazon/renton/1/rpm"
+					}`),
+			},
+		},
+	})
+	require.Nil(t, err)
+	_, ok := qdr.Responses["A"]
+	require.True(t, ok)
+	require.NotNil(t, qdr.Responses["A"].Frames[0])
+
+	expectedFrame := data.NewFrame("",
+		data.NewField("time", nil, []time.Time{time.Date(2021, 2, 1, 19, 20, 0, 0, time.UTC)}),
+		data.NewField("/amazon/renton/1/rpm", nil, []int64{23}).SetConfig(&data.FieldConfig{Unit: ""}),
+		data.NewField("quality", nil, []string{"GOOD"}),
+	)
+	if diff := cmp.Diff(expectedFrame, qdr.Responses["A"].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
+	}
+
+	mockSw.AssertExpectations(t)
+	mockSw.AssertCalled(t,
+		"DescribeTimeSeriesWithContext",
+		mock.Anything,
+		&iotsitewise.DescribeTimeSeriesInput{Alias: Pointer("/amazon/renton/1/rpm")},
+	)
+	mockSw.AssertCalled(t,
+		"BatchGetAssetPropertyValueWithContext",
+		mock.Anything,
+		&iotsitewise.BatchGetAssetPropertyValueInput{
+			Entries: []*iotsitewise.BatchGetAssetPropertyValueEntry{{
+				EntryId:       Pointer("61e4e1a8ab39463fa0b9418d9be2923e364f40a8b935b69d006b999516cdecef"),
+				PropertyAlias: Pointer("/amazon/renton/1/rpm"),
+			}},
+		},
+	)
+	mockSw.AssertNotCalled(t,
+		"DescribeAssetPropertyWithContext",
+		mock.Anything,
+		mock.Anything,
+	)
+}
 func Test_property_value_query_with_empty_property_value_results(t *testing.T) {
 	mockSw := &mocks.SitewiseClient{}
 	mockSw.On("BatchGetAssetPropertyValueWithContext", mock.Anything, mock.Anything).Return(&iotsitewise.BatchGetAssetPropertyValueOutput{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

We currently can't fetch the data type for disassociated data streams. This is because the describe asset property API doesn't support querying by alias, instead it requires an asset id and property id. See the following code where the `DataType` is set to `"?"`

https://github.com/grafana/iot-sitewise-datasource/blob/ef82f351fab5cd8c08c3682e348d4c834aa0f34a/pkg/resource/sitewise.go#L30-L45

Since we don't know the data type, when we're building up the frame, we were incorrectly inferring the data type to be a float64 (which is what we infer a field's value type to be by default)

https://github.com/grafana/iot-sitewise-datasource/blob/ef82f351fab5cd8c08c3682e348d4c834aa0f34a/pkg/framer/fields/util.go#L8-L19

This PR uses an existing utility function to infer the correct data type before we start building up the frame. This existing utility function is already used by other query types, e.g. property value history, that's why those ones were not erroring.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #270 

**Special notes for your reviewer**:

To test:
- Use the external dev account which I created a disassociated data stream with an integer value in
- Set query type to `Get property value`
- Set the alias to `/test/int/value`
- Run the query