### PR TITLE
fix: asset property list render

### DIFF
--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -446,7 +446,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
                       id="property"
                       aria-label="Property"
                       isLoading={loading}
-                      options={assetProperties}
+                      options={assetPropertyOptions}
                       value={currentAssetPropertyOption ?? null}
                       onChange={this.onPropertyChange}
                       placeholder="Select a property"
@@ -543,7 +543,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
                 <InlineField label="Property" labelWidth={firstLabelWith} grow={true}>
                   <Select
                     isLoading={loading}
-                    options={assetProperties}
+                    options={assetPropertyOptions}
                     value={currentAssetPropertyOption ?? null}
                     onChange={this.onPropertyChange}
                     placeholder="Select a property"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**: https://github.com/grafana/iot-sitewise-datasource/pull/279 included a change which caused the asset property drop-down to not render the asset property names. This is due to a reference to the wrong list, which was not caught by TypeScript, as the `options` prop of `<Select />` does not have strong type safety (i.e., it only requires a list of type `T`).

https://github.com/grafana/iot-sitewise-datasource/pull/285 acts as an effective regression test to ensure asset property list is functional.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->