### PR TITLE
E2E: Publish report only when the branch is not a fork

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,7 +72,7 @@ jobs:
         run: yarn playwright test
 
       - name: Publish report to GCS
-        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') && github.event.organization.login == 'grafana' && github.event.pull_request.head.repo.fork == false }}
+        if: ${{ github.repository_owner == 'grafana' && (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
         uses: grafana/plugin-actions/publish-report@main
         with:
           grafana-version: ${{ matrix.GRAFANA_IMAGE.VERSION }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,7 +72,7 @@ jobs:
         run: yarn playwright test
 
       - name: Publish report to GCS
-        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') && github.event.organization.login == 'grafana' }}
+        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') && github.event.organization.login == 'grafana' && github.event.pull_request.head.repo.fork == false }}
         uses: grafana/plugin-actions/publish-report@main
         with:
           grafana-version: ${{ matrix.GRAFANA_IMAGE.VERSION }}


### PR DESCRIPTION
The `grafana/plugin-actions/publish-report` action should only run for Grafana employees. Adding an extra condition to check if the PR is not a fork before running the action.