### PR TITLE
Query Editor: Improve menu placement for dropdowns 

### DIFF
--- a/src/components/query/ListAssetsQueryEditor.tsx
+++ b/src/components/query/ListAssetsQueryEditor.tsx
@@ -81,7 +81,7 @@ export class ListAssetsQueryEditor extends PureComponent<Props, State> {
               isClearable={true}
               isSearchable={true}
               formatCreateLabel={(txt) => `Model ID: ${txt}`}
-              menuPlacement="bottom"
+              menuPlacement="auto"
             />
           </EditorField>
           <EditorField label="Filter" htmlFor="filter" width={20}>
@@ -92,7 +92,7 @@ export class ListAssetsQueryEditor extends PureComponent<Props, State> {
               value={filters.find((v) => v.value === query.filter) || filters[0]}
               onChange={this.onFilterChange}
               placeholder="Select a property"
-              menuPlacement="bottom"
+              menuPlacement="auto"
             />
           </EditorField>
         </EditorFieldGroup>

--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -243,7 +243,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
             stats={query.aggregates ?? []}
             onChange={this.onAggregateChange}
             defaultStat={getDefaultAggregate(property)}
-            menuPlacement="bottom"
+            menuPlacement="auto"
           />
         </EditorField>
         <EditorField label="Resolution" htmlFor="resolution" width={25}>
@@ -253,7 +253,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
             options={resolutions}
             value={resolutions.find((v) => v.value === query.resolution) || resolutions[0]}
             onChange={this.onResolutionChange}
-            menuPlacement="bottom"
+            menuPlacement="auto"
           />
         </EditorField>
       </EditorFieldGroup>
@@ -316,7 +316,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
           isSearchable={true}
           onCreateOption={this.onSetHierarchyId}
           formatCreateLabel={(txt) => `Hierarchy Id: ${txt}`}
-          menuPlacement="bottom"
+          menuPlacement="auto"
         />
       </EditorField>
     ) : (
@@ -426,7 +426,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
                     isSearchable={true}
                     onCreateOption={this.onSetAssetId}
                     formatCreateLabel={(txt) => `Asset ID: ${txt}`}
-                    menuPlacement="bottom"
+                    menuPlacement="auto"
                   />
                 </EditorField>
 
@@ -457,7 +457,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
                       isSearchable={true}
                       onCreateOption={this.onSetPropertyId}
                       formatCreateLabel={(txt) => `Property ID: ${txt}`}
-                      menuPlacement="bottom"
+                      menuPlacement="auto"
                     />
                   </EditorField>
                 </EditorFieldGroup>

--- a/src/components/query/QualityAndOrderRow.tsx
+++ b/src/components/query/QualityAndOrderRow.tsx
@@ -100,7 +100,7 @@ export class QualityAndOrderRow extends PureComponent<Props> {
             value={qualities.find((v) => v.value === query.quality) ?? qualities[0]}
             onChange={this.onQualityChange}
             isSearchable={true}
-            menuPlacement="bottom"
+            menuPlacement="auto"
           />
         </EditorField>
         <EditorField label="Time" width={10} htmlFor="time">
@@ -111,7 +111,7 @@ export class QualityAndOrderRow extends PureComponent<Props> {
             value={ordering.find((v) => v.value === query.timeOrdering) ?? ordering[0]}
             onChange={this.onOrderChange}
             isSearchable={true}
-            menuPlacement="bottom"
+            menuPlacement="auto"
           />
         </EditorField>
         <EditorField label="Format" width={10} htmlFor="format">
@@ -131,7 +131,7 @@ export class QualityAndOrderRow extends PureComponent<Props> {
               options={interpolatedResolutions}
               value={interpolatedResolutions.find((v) => v.value === query.resolution) || interpolatedResolutions[0]}
               onChange={this.onResolutionChange}
-              menuPlacement="bottom"
+              menuPlacement="auto"
             />
           </EditorField>
         )}

--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -96,7 +96,7 @@ export function QueryEditor(props: Props) {
                     value={currentQueryType}
                     onChange={onQueryTypeChange}
                     placeholder="Select query type"
-                    menuPlacement="bottom"
+                    menuPlacement="auto"
                   />
                 </EditorField>
                 <EditorField label="Region" width={15}>
@@ -107,7 +107,7 @@ export function QueryEditor(props: Props) {
                     backspaceRemovesValue={true}
                     allowCustomValue={true}
                     isClearable={true}
-                    menuPlacement="bottom"
+                    menuPlacement="auto"
                   />
                 </EditorField>
               </EditorFieldGroup>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

Sometimes when dropdowns have a lot of items, some of them are not visible because the Select prop always places the dopdown on the bottom. This changes the placement to "auto".

**Before:**
<img width="500" alt="Screenshot 2024-03-18 at 17 27 51" src="https://github.com/grafana/iot-sitewise-datasource/assets/16140639/1c85d338-7117-4118-9c74-654bce39868d">


**After:**
<img width="500" alt="Screenshot 2024-03-18 at 17 18 32" src="https://github.com/grafana/iot-sitewise-datasource/assets/16140639/f079b63b-eb33-4714-9e51-7cd0824b55ff">


