### PR TITLE
Add E2E tests for config editor, add support for generating mocks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run Playwright tests
         id: run-tests
-        run: yarn playwright test
+        run: yarn run test:e2e:use-mocks
 
       - name: Publish report to GCS
         if: ${{ github.repository_owner == 'grafana' && (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@ __debug_bin
 /playwright/.cache/
 /playwright/.auth/
 
-# ignore all provisioning files except for e2e placeholders.
+# ignore all provisioning files except for mocks
 provisioning/datasources/*
-!provisioning/datasources/*.e2e.yaml
+!provisioning/datasources/mock-iot-sitewise.e2e.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,3 +114,47 @@ You need to have commit rights to the GitHub repository to publish a release.
 2. Update the `CHANGELOG.md` by copy and pasting the relevant PRs from [Github's Release drafter interface](https://github.com/grafana/iot-sitewise-datasource/releases/new) or by running `yarn generate-release-notes` (you'll need to install the [gh cli](https://cli.github.com/) and [jq](https://jqlang.github.io/jq/) to run this command).
 3. PR the changes.
 4. Once merged, follow the Drone release process that you can find [here](https://github.com/grafana/integrations-team/wiki/Plugin-Release-Process#drone-release-process)
+
+## E2E Tests
+
+This plugin uses [playwright](https://playwright.dev/) and [@grafana/plugin-e2e](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e) for e2e end tests.
+
+We support writing/running e2e tests against both mock and live data. Hitting live endpoints in AWS gives us the best fidelity but is potentially difficult for external contributors, as they won't share our internal AWS credentials. Using live endpoints can also sometimes be slow, or run into potential rate limiting issues if we run many tests at once. To get around these issues we allow developers to run their tests against mock data, and also have made it easier to record live data and generate mock data for tests. See helper functions in the handleMocks.ts file to generate and/or call mocks.
+
+To run existing e2e tests we have several scripts to choose from:
+
+- `yarn run test:e2e:debug` will open up playwright's ui mode so you can see screenshots and debug broken tests more easily. This will also use mocks.
+- `test:e2e:use-mocks` to run all tests with mocks in the terminal (no ui mode)
+- `test:e2e:use-live-data` to run all tests with live data
+- `test:e2e:use-live-data:generate-mocks` to run all tests with live data and also generate/overwrite any existing mocks.
+
+To use the live data mode, you'll need to create a yaml file in provisioning/datasources called `iot-sitewise.e2e.yaml` and add the following:
+
+```
+apiVersion: 1
+
+deleteDatasources:
+  - name: e2e-sitewise-invalid-credentials
+    orgId: 1
+  - name: e2e-sitewise-valid-credentials
+    orgId: 1
+
+datasources:
+  - name: e2e-sitewise-invalid-credentials
+    type: grafana-iot-sitewise-datasource
+    defaultRegion: us-east-1
+    editable: true
+    secureJsonData:
+      accessKey: invalid-mock-access-key
+      secretKey: invalid-mock-secret-key
+
+  - name: e2e-sitewise-valid-credentials
+    type: grafana-iot-sitewise-datasource
+    editable: true
+    jsonData:
+      authType: keys
+      defaultRegion: us-east-1
+    secureJsonData:
+      accessKey: { put your access key here that has access to sitewise in aws }
+      secretKey: { put your secret key here that has access to sitewise in aws }
+```

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
-    "e2e": "yarn exec cypress install && yarn exec grafana-e2e run",
-    "e2e:update": "yarn exec cypress install && yarn exec grafana-e2e run --update-screenshots",
     "generate-release-notes": "PREV_TAG=$(git tag | tail -n 1) && gh api --method POST /repos/grafana/iot-sitewise-datasource/releases/generate-notes -f tag_name=v${npm_package_version} -f target_commitish=main -f previous_tag_name=${PREV_TAG} | jq -r .body",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
@@ -18,6 +16,10 @@
     "typecheck": "tsc --noEmit",
     "test:coverage": "jest --coverage",
     "test:coverage:changes": "jest --coverage --changedSince=origin/main",
+    "test:e2e:debug": "USE_MOCKS=true npx playwright test --ui",
+    "test:e2e:use-mocks": "USE_MOCKS=true npx playwright test",
+    "test:e2e:use-live-data": "npx playwright test",
+    "test:e2e:use-live-data:generate-mocks": "GENERATE_MOCKS=true npx playwright test",
     "watch": "webpack -w -c ./.config/webpack/webpack.config.ts --env development"
   },
   "repository": "github:grafana/iot-sitewise-datasource",

--- a/provisioning/datasources/mock-iot-sitewise.e2e.yaml
+++ b/provisioning/datasources/mock-iot-sitewise.e2e.yaml
@@ -3,9 +3,34 @@ apiVersion: 1
 deleteDatasources:
   - name: E2E Mock IoT SiteWise
     orgId: 1
+  - name: e2e-sitewise-invalid-credentials
+    orgId: 1
+  - name: e2e-sitewise-valid-credentials
+    orgId: 1
 
 datasources:
   - name: E2E Mock IoT SiteWise
     type: grafana-iot-sitewise-datasource
+    editable: true
     uid: e2e-mock-iot-sitewise
     version: 1
+
+  - name: e2e-sitewise-invalid-credentials
+    type: grafana-iot-sitewise-datasource
+    uid: e2e-sitewise-invalid-credentials
+    editable: true
+    defaultRegion: us-east-1
+    secureJsonData:
+      accessKey: invalid-mock-access-key
+      secretKey: invalid-mock-secret-key
+
+  - name: e2e-sitewise-valid-credentials
+    type: grafana-iot-sitewise-datasource
+    uid: e2e-sitewise-valid-credentials
+    editable: true
+    jsonData:
+      authType: keys
+      defaultRegion: us-east-1
+    secureJsonData:
+      accessKey: very-valid-mock-access-key
+      secretKey: very-valid-mock-access-key

--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@grafana/plugin-e2e';
+import { SitewiseOptions, SitewiseSecureJsonData } from '../src/types';
+import { handleMocks } from './handleMocks';
+
+test.describe('ConfigEditor', () => {
+  test('invalid credentials should return a 400 status code', async ({
+    createDataSourceConfigPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const provisionedDatasource = await handleMocks(page, '/health', 'e2e-sitewise-invalid-credentials');
+
+    // create a new datasource
+    const configPage = await createDataSourceConfigPage({
+      type: 'grafana-iot-sitewise-datasource',
+    });
+    await page.getByLabel(/^Authentication Provider/).fill('Access & secret key');
+    await page.keyboard.press('Enter');
+
+    // get the provisioned datasource options
+    const ds = await readProvisionedDataSource<SitewiseOptions, SitewiseSecureJsonData>(provisionedDatasource);
+
+    // fill in the config form
+    await page.getByLabel('Name').fill(ds.name || '');
+    await page.getByLabel('Access Key ID').fill(ds.secureJsonData?.accessKey || '');
+    await page.getByLabel('Secret Access Key').fill(ds.secureJsonData?.secretKey || '');
+    await page.getByLabel('Default Region').fill('us-east-1');
+    await page.keyboard.press('Enter');
+
+    // click save and test
+    const response = await configPage.saveAndTest();
+
+    // expect network response have error (this is only a meaningful test when we run this with live (not mocked) data)
+    const body = await response.json();
+    expect(body).toHaveProperty('status', 'ERROR');
+    expect(body.message).toContain('invalid');
+
+    // expect error to be shown in the UI
+    const errorMessage = await page.getByText('The security token included in the request is invalid');
+    expect(errorMessage).toBeVisible();
+  });
+
+  test('valid credentials should return a 200 status code', async ({
+    createDataSourceConfigPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const provisionedDatasource = await handleMocks(page, '/health', 'e2e-sitewise-valid-credentials');
+
+    // create a new datasource
+    const configPage = await createDataSourceConfigPage({ type: 'grafana-iot-sitewise-datasource' });
+    await page.getByLabel(/^Authentication Provider/).fill('Access & secret key');
+    await page.keyboard.press('Enter');
+
+    // get the provisioned datasource options
+    const ds = await readProvisionedDataSource<SitewiseOptions, SitewiseSecureJsonData>(provisionedDatasource);
+
+    // fill in the config form
+    await page.getByLabel('Name').fill(ds.name || '');
+    await page.getByLabel('Access Key ID').fill(ds.secureJsonData?.accessKey || '');
+    await page.getByLabel('Secret Access Key').fill(ds.secureJsonData?.secretKey || '');
+    await page.getByLabel('Default Region').fill('us-east-1');
+    await page.keyboard.press('Enter');
+
+    // click save and test
+    const response = await configPage.saveAndTest();
+
+    // expect network response have error (this is only a meaningful test when we run this with live (not mocked) data)
+    const body = await response.json();
+    expect(body).toHaveProperty('status', 'OK');
+
+    // expect success message to be shown in the UI
+    const successMessage = page.getByText('OK');
+    expect(successMessage).toBeVisible();
+  });
+});

--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -21,7 +21,6 @@ test.describe('ConfigEditor', () => {
     const ds = await readProvisionedDataSource<SitewiseOptions, SitewiseSecureJsonData>(provisionedDatasource);
 
     // fill in the config form
-    await page.getByLabel('Name').fill(ds.name || '');
     await page.getByLabel('Access Key ID').fill(ds.secureJsonData?.accessKey || '');
     await page.getByLabel('Secret Access Key').fill(ds.secureJsonData?.secretKey || '');
     await page.getByLabel('Default Region').fill('us-east-1');
@@ -56,7 +55,6 @@ test.describe('ConfigEditor', () => {
     const ds = await readProvisionedDataSource<SitewiseOptions, SitewiseSecureJsonData>(provisionedDatasource);
 
     // fill in the config form
-    await page.getByLabel('Name').fill(ds.name || '');
     await page.getByLabel('Access Key ID').fill(ds.secureJsonData?.accessKey || '');
     await page.getByLabel('Secret Access Key').fill(ds.secureJsonData?.secretKey || '');
     await page.getByLabel('Default Region').fill('us-east-1');

--- a/tests/handleMocks.ts
+++ b/tests/handleMocks.ts
@@ -52,7 +52,7 @@ const returnMockForEndpoint = async (page: Page, endpoint: string, mockName: str
 // to run tests with mocks: yarn run test:e2e:use-mocks
 // to run tests with live endpoints: yarn run test:e2e:use-live-data
 // to run tests with live endpoints and generate mocks from the responses: yarn run test:e2e:use-live-data:generate-mocks
-// when using live endpoints be sure to create a provisioned datasource in provisoning/datasources/iot-sitewise.e2e.yaml
+// when using live endpoints be sure to create a provisioned datasource in provisioning/datasources/iot-sitewise.e2e.yaml
 export const handleMocks = async (page: Page, endpoint: string, testCaseName: string) => {
   if (process.env.GENERATE_MOCKS === 'true') {
     generateMockForEndpoint(page, endpoint, testCaseName);

--- a/tests/handleMocks.ts
+++ b/tests/handleMocks.ts
@@ -1,0 +1,74 @@
+import { Page, Response } from '@playwright/test';
+import path from 'path';
+import { promises as fsPromises, constants as fsConstants } from 'fs';
+
+const mocksFolderPath = path.join(__dirname, 'mocks');
+
+const generateMock = async (mockName: string, mockResponse: Response) => {
+  // First, check that the mocks folder exists and if not create it
+  try {
+    await fsPromises.access(mocksFolderPath, fsConstants.F_OK);
+  } catch (err) {
+    console.log('Creating mocks folder');
+    await fsPromises.mkdir(mocksFolderPath, { recursive: true });
+  }
+
+  // then take the response body and write it to a json file in the mocks folder
+  try {
+    const bufferBody = await mockResponse.body();
+    const filePath = `${mocksFolderPath}/${mockName}.json`;
+    await fsPromises.writeFile(filePath, bufferBody);
+  } catch (err) {
+    throw new Error(`Unable to generate mocks for ${mockName}: - ${err}`);
+  }
+};
+
+// for a given endpoint, subscribes to the response and generates/stores a mock file
+const generateMockForEndpoint = async (page: Page, endpoint: string, mockName: string) => {
+  page.on('response', async (response) => {
+    const url = response.url();
+    if (url.includes(endpoint)) {
+      generateMock(mockName, response);
+    }
+  });
+};
+
+// for a given endpoint, will replace a response with a mocked response if one exists
+const returnMockForEndpoint = async (page: Page, endpoint: string, mockName: string) => {
+  await page.route(`**${endpoint}`, async (route) => {
+    const mockFiles = await fsPromises.readdir(path.join(__dirname, 'mocks'));
+    if (mockFiles.includes(`${mockName}.json`)) {
+      const filePath = path.join(__dirname, `mocks/${mockName}.json`);
+      const data = await fsPromises.readFile(filePath);
+      route.fulfill({ body: data });
+    } else {
+      throw new Error(`No mock found for ${mockName}`);
+    }
+  });
+};
+
+// will return back either a mocked or live provisioned datasource depending on settings
+// also responsible for generating mocks if GENERATE_MOCKS is set to true
+// to run tests with mocks: yarn run test:e2e:use-mocks
+// to run tests with live endpoints: yarn run test:e2e:use-live-data
+// to run tests with live endpoints and generate mocks from the responses: yarn run test:e2e:use-live-data:generate-mocks
+// when using live endpoints be sure to create a provisioned datasource in provisoning/datasources/iot-sitewise.e2e.yaml
+export const handleMocks = async (page: Page, endpoint: string, testCaseName: string) => {
+  if (process.env.GENERATE_MOCKS === 'true') {
+    generateMockForEndpoint(page, endpoint, testCaseName);
+  }
+
+  if (process.env.USE_MOCKS === 'true') {
+    returnMockForEndpoint(page, endpoint, testCaseName);
+  }
+
+  let fileName = 'iot-sitewise.e2e.yaml';
+  if (process.env.USE_MOCKS === 'true') {
+    fileName = 'mock-iot-sitewise.e2e.yaml';
+  }
+
+  return {
+    fileName: fileName,
+    name: testCaseName,
+  };
+};

--- a/tests/mocks/e2e-sitewise-invalid-credentials.json
+++ b/tests/mocks/e2e-sitewise-invalid-credentials.json
@@ -1,0 +1,1 @@
+{"message":"unable to test ListAssetModels: UnrecognizedClientException: The security token included in the request is invalid.\n\tstatus code: 403, request id: 632bc159-551b-4bf9-9c0e-8a9461841c8b","status":"ERROR"}

--- a/tests/mocks/e2e-sitewise-invalid-credentials.json
+++ b/tests/mocks/e2e-sitewise-invalid-credentials.json
@@ -1,1 +1,1 @@
-{"message":"unable to test ListAssetModels: UnrecognizedClientException: The security token included in the request is invalid.\n\tstatus code: 403, request id: 632bc159-551b-4bf9-9c0e-8a9461841c8b","status":"ERROR"}
+{"message":"unable to test ListAssetModels: UnrecognizedClientException: The security token included in the request is invalid.\n\tstatus code: 403, request id: 0a6304ae-8ec7-4773-8b14-6e3dd40a2ac5","status":"ERROR"}

--- a/tests/mocks/e2e-sitewise-valid-credentials.json
+++ b/tests/mocks/e2e-sitewise-valid-credentials.json
@@ -1,0 +1,1 @@
+{"message":"OK","status":"OK"}

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -11,6 +11,7 @@ test.describe('Query Editor', () => {
 
       const ds = await readProvisionedDataSource<SitewiseOptions, SitewiseSecureJsonData>({
         fileName: 'mock-iot-sitewise.e2e.yaml',
+        name: 'E2E Mock IoT SiteWise',
       });
       await panelEditPage.datasource.set(ds.name);
       await panelEditPage.setVisualization('Table');


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds e2e tests for the config editor, also adds some helpers for generating mocks from live data for tests. 

**Which issue(s) this PR fixes**:

relates to https://github.com/grafana/iot-sitewise-datasource/issues/212

**Special notes for your reviewer**:
To run the tests against live data you'll need to follow the directions specified in teh contributing.md in this pr. Let me know if they make sense!