### PR TITLE
Fix fetching asset properties

### DIFF
--- a/pkg/models/asset.go
+++ b/pkg/models/asset.go
@@ -22,8 +22,8 @@ type ListAssetsQuery struct {
 
 type ListAssociatedAssetsQuery struct {
 	BaseQuery
-	HierarchyId string `json:"hierarchyId,omitempty"`
-	LoadAllChildren bool `json:"loadAllChildren,omitempty"`
+	HierarchyId     string `json:"hierarchyId,omitempty"`
+	LoadAllChildren bool   `json:"loadAllChildren,omitempty"`
 	// TraversalDirection is implied from the existence of HierarchyId
 }
 
@@ -48,11 +48,7 @@ func GetListAssetPropertiesQuery(dq *backend.DataQuery) (*ListAssetPropertiesQue
 		return nil, err
 	}
 
-	// AssetId <--> AssetIds backward compatibility
-	query.MigrateAssetId()
-
 	query.QueryType = dq.QueryType
-
 	return query, nil
 }
 

--- a/pkg/sitewise/api/list_asset_properties.go
+++ b/pkg/sitewise/api/list_asset_properties.go
@@ -9,23 +9,22 @@ import (
 	"github.com/grafana/iot-sitewise-datasource/pkg/framer"
 	"github.com/grafana/iot-sitewise-datasource/pkg/models"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client"
-	"github.com/grafana/iot-sitewise-datasource/pkg/util"
 )
 
 func ListAssetProperties(ctx context.Context, client client.SitewiseClient, query models.ListAssetPropertiesQuery) (*framer.AssetProperties, error) {
 	resp, err := client.ListAssetPropertiesWithContext(ctx, &iotsitewise.ListAssetPropertiesInput{
-		AssetId: util.GetAssetId(query.BaseQuery),
-		Filter: aws.String("ALL"),
+		AssetId:    &query.AssetId,
+		Filter:     aws.String("ALL"),
 		MaxResults: aws.Int64(250),
-		NextToken: getNextToken(query.BaseQuery),
+		NextToken:  getNextToken(query.BaseQuery),
 	})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &framer.AssetProperties {
+	return &framer.AssetProperties{
 		AssetPropertySummaries: resp.AssetPropertySummaries,
-		NextToken: resp.NextToken,
+		NextToken:              resp.NextToken,
 	}, nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
Fixes fetching asset properties. Instead of calling `util.GetAssetId` on the base query it should use the assetId on the wrapper query.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #301 

**Special notes for your reviewer**: