### PR TITLE
Migrate to CustomVariableSupport

### DIFF
--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -53,6 +53,7 @@ describe('Sitewise Datasource', () => {
       const query: SitewiseQuery = {
         refId: 'RefA',
         queryType: QueryType.ListAssociatedAssets,
+        assetId: '',
         assetIds: ['${assetIdConstant}'],
         propertyAlias: '',
         region: 'default',
@@ -68,6 +69,7 @@ describe('Sitewise Datasource', () => {
       const query: SitewiseQuery = {
         refId: 'RefA',
         queryType: QueryType.ListAssociatedAssets,
+        assetId: '',
         assetIds: ['${assetIdArray}'],
         propertyAlias: '',
         region: 'default',
@@ -84,6 +86,7 @@ describe('Sitewise Datasource', () => {
         refId: 'RefA',
         queryType: QueryType.ListAssociatedAssets,
         assetIds: ['${assetIdConstant}', '${assetIdArray}'],
+        assetId: '',
         propertyAlias: '',
         region: 'default',
         propertyId: '',
@@ -98,6 +101,7 @@ describe('Sitewise Datasource', () => {
       const query: SitewiseQuery = {
         refId: 'RefA',
         queryType: QueryType.ListAssociatedAssets,
+        assetId: '',
         assetIds: ['${assetIdConstant}'],
         propertyAlias: '',
         region: 'default',
@@ -117,6 +121,7 @@ describe('Sitewise Datasource', () => {
       const query: SitewiseQuery = {
         refId: 'RefA',
         queryType: QueryType.ListAssociatedAssets,
+        assetId: '',
         assetIds: ['${assetIdConstant}', 'noVar', '${assetIdArray}'],
         propertyAlias: '',
         region: 'default',

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -14,6 +14,7 @@ import { Observable } from 'rxjs';
 import { getRequestLooper, MultiRequestTracker } from 'requestLooper';
 import { appendMatchingFrames } from 'appendFrames';
 import { frameToMetricFindValues } from 'utils';
+import { SitewiseVariableSupport } from 'variables';
 
 export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOptions> {
   // Easy access for QueryEditor
@@ -23,6 +24,7 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
   constructor(instanceSettings: DataSourceInstanceSettings<SitewiseOptions>) {
     super(instanceSettings);
     this.options = instanceSettings.jsonData;
+    this.variables = new SitewiseVariableSupport(this);
   }
 
   /**
@@ -129,6 +131,7 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
       propertyAlias: templateSrv.replace(query.propertyAlias, scopedVars),
       region: templateSrv.replace(query.region || '', scopedVars),
       propertyId: templateSrv.replace(query.propertyId || '', scopedVars),
+      assetId: templateSrv.replace(query.assetId || '', scopedVars),
       assetIds: query.assetIds?.flatMap((assetId) => templateSrv.replace(assetId, scopedVars, 'csv').split(',')) ?? [],
     };
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,5 +8,4 @@ import { QueryEditor } from 'components/query/QueryEditor';
 export const plugin = new DataSourcePlugin<DataSource, SitewiseQuery, SitewiseOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
   .setMetadataInspector(MetaInspector)
-  .setVariableQueryEditor(QueryEditor)
   .setQueryEditor(QueryEditor);

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,52 @@
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { assign } from 'lodash';
+import { QueryType, SitewiseQuery } from './types';
+import { DataSource } from './DataSource';
+import { DataQueryRequest, DataQueryResponse, CustomVariableSupport, DataFrameView } from '@grafana/data';
+import { QueryEditor } from './components/query/QueryEditor';
+import { AssetModelSummary } from 'queryResponseTypes';
+
+export class SitewiseVariableSupport extends CustomVariableSupport<DataSource, SitewiseQuery, SitewiseQuery> {
+  constructor(private readonly datasource: DataSource) {
+    super();
+    this.datasource = datasource;
+    this.query = this.query.bind(this);
+  }
+
+  editor = QueryEditor;
+
+  query(request: DataQueryRequest<SitewiseQuery>): Observable<DataQueryResponse> {
+    assign(request.targets, [{ ...request.targets[0], refId: 'A' }]);
+    let response = this.datasource.query(request);
+    switch (request.targets[0].queryType) {
+      case QueryType.ListAssetModels:
+      case QueryType.ListAssets:
+      case QueryType.ListAssociatedAssets:
+        return this.parseOptions(response);
+      default:
+        return response
+    }
+  }
+
+  parseOptions(response: Observable<DataQueryResponse> ): Observable<DataQueryResponse> {
+    return response.pipe(
+      map((res) => {
+        let data = []
+        if (res.data.length) {
+          data = res.data[0]
+        }
+        return {data: new DataFrameView<AssetModelSummary>(data)};
+      }),
+      map((res) => {
+        let newData = res.data.map((m)=>{
+          return {
+          value: m.id,
+          text: m.name,
+        }})
+        return {data:newData}
+      })
+    )
+  }
+
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
Migrates from the deprecated variable support to `CustomVariableSupport`. I created an [issue](https://github.com/grafana/iot-sitewise-datasource/issues/305) to actually design a new proper variable editor for this with resource handlers for the backend and an [issue](https://github.com/grafana/iot-sitewise-datasource/issues/306) to handle assetId and assetIds more consistently.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #233

**Special notes for your reviewer**: