### PR TITLE
Fetch properties using both AssetId and AssetIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.19.0
+
+- Fetch properties using both AssetId and AssetIds in (#307)[https://github.com/grafana/iot-sitewise-datasource/pull/307]
+- Migrate to CustomVariableSupport in (#304)[https://github.com/grafana/iot-sitewise-datasource/pull/304]
+
 ## 1.18.0
 
 - Fix fetching asset properties in (#302)[https://github.com/grafana/iot-sitewise-datasource/pull/302]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-sitewise-datasource",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "View IoT Sitewise data in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/models/asset.go
+++ b/pkg/models/asset.go
@@ -48,6 +48,9 @@ func GetListAssetPropertiesQuery(dq *backend.DataQuery) (*ListAssetPropertiesQue
 		return nil, err
 	}
 
+	// AssetId <--> AssetIds backward compatibility
+	query.MigrateAssetId()
+
 	query.QueryType = dq.QueryType
 	return query, nil
 }

--- a/pkg/models/property.go
+++ b/pkg/models/property.go
@@ -12,7 +12,6 @@ const (
 
 type ListAssetPropertiesQuery struct {
 	BaseQuery
-	AssetId string `json:"assetId,omitempty"`
 }
 
 // AssetPropertyValueQuery encapsulates params for all 3 'Get' data APIs in Sitewise.

--- a/pkg/server/test/list_asset_properties_test.go
+++ b/pkg/server/test/list_asset_properties_test.go
@@ -23,17 +23,17 @@ var listAssetPropertiesHappyCase testServerScenarioFn = func(t *testing.T) *test
 	mockSw.On("ListAssetPropertiesWithContext", mock.Anything, mock.Anything).Return(&assetProperties, nil)
 
 	query := models.ListAssetPropertiesQuery{
-		AssetId: "123",
+		BaseQuery: models.BaseQuery{AssetId: "123"},
 	}
 
 	return &testScenario{
-		name: "TestListAssetPropertiesResponseHappyCase",
+		name:   "TestListAssetPropertiesResponseHappyCase",
 		mockSw: mockSw,
 		queries: []backend.DataQuery{
 			{
-				RefID: "A",
+				RefID:     "A",
 				QueryType: models.QueryTypeListAssetProperties,
-				JSON: testdata.SerializeStruct(t, query),
+				JSON:      testdata.SerializeStruct(t, query),
 			},
 		},
 		goldenFileName: "list-asset-properties",

--- a/pkg/sitewise/api/list_asset_properties.go
+++ b/pkg/sitewise/api/list_asset_properties.go
@@ -9,11 +9,12 @@ import (
 	"github.com/grafana/iot-sitewise-datasource/pkg/framer"
 	"github.com/grafana/iot-sitewise-datasource/pkg/models"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client"
+	"github.com/grafana/iot-sitewise-datasource/pkg/util"
 )
 
 func ListAssetProperties(ctx context.Context, client client.ListAssetPropertiesClient, query models.ListAssetPropertiesQuery) (*framer.AssetProperties, error) {
 	resp, err := client.ListAssetPropertiesWithContext(ctx, &iotsitewise.ListAssetPropertiesInput{
-		AssetId:    &query.AssetId,
+		AssetId:    util.GetAssetId(query.BaseQuery),
 		Filter:     aws.String("ALL"),
 		MaxResults: aws.Int64(250),
 		NextToken:  getNextToken(query.BaseQuery),

--- a/pkg/sitewise/api/list_asset_properties_test.go
+++ b/pkg/sitewise/api/list_asset_properties_test.go
@@ -26,7 +26,7 @@ func (f *fakeListAssetPropertiesClient) ListAssetPropertiesWithContext(ctx aws.C
 func TestListAssetProperties(t *testing.T) {
 	client := fakeListAssetPropertiesClient{}
 	query := models.ListAssetPropertiesQuery{
-		AssetId: "foo",
+		BaseQuery: models.BaseQuery{AssetIds: []string{"foo"}},
 	}
 	framer, err := api.ListAssetProperties(context.Background(), &client, query)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
Fixes listProperties to use both AssetId and AssetIds to fetch properties

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #308 

**Special notes for your reviewer**: