### PR TITLE
perf(api): batch APIs queries to request for maximum number of datapo…

### DIFF
--- a/pkg/sitewise/api/constants.go
+++ b/pkg/sitewise/api/constants.go
@@ -1,0 +1,8 @@
+package api
+
+const (
+	// Max results number from: https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchGetAssetPropertyValueHistory.html#iotsitewise-BatchGetAssetPropertyValueHistory-request-maxResults
+	BatchGetAssetPropertyValueHistoryMaxResults = 20000
+	// Max results number from: https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_BatchGetAssetPropertyAggregates.html#iotsitewise-BatchGetAssetPropertyAggregates-request-maxResults
+	BatchGetAssetPropertyAggregatesMaxResults = 4000
+)

--- a/pkg/sitewise/api/property_aggregate_batch.go
+++ b/pkg/sitewise/api/property_aggregate_batch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/iot-sitewise-datasource/pkg/util"
 )
 
+// `query.MaxDataPoints` is ignored and it always requests with the maximum number of data points the SiteWise API can support
 func aggregateBatchQueryToInput(query models.AssetPropertyValueQuery) *iotsitewise.BatchGetAssetPropertyAggregatesInput {
 
 	resolution := query.Resolution
@@ -38,10 +39,6 @@ func aggregateBatchQueryToInput(query models.AssetPropertyValueQuery) *iotsitewi
 
 	if query.TimeOrdering != "" {
 		timeOrdering = aws.String(query.TimeOrdering)
-	}
-
-	if query.MaxDataPoints < 1 || query.MaxDataPoints > 250 {
-		query.MaxDataPoints = 250
 	}
 
 	entries := make([]*iotsitewise.BatchGetAssetPropertyAggregatesEntry, 0)
@@ -79,8 +76,9 @@ func aggregateBatchQueryToInput(query models.AssetPropertyValueQuery) *iotsitewi
 	}
 
 	return &iotsitewise.BatchGetAssetPropertyAggregatesInput{
-		Entries:    entries,
-		MaxResults: aws.Int64(query.MaxDataPoints),
+		Entries: entries,
+		// performance: hardcoded to fetch the maximum number of data points
+		MaxResults: aws.Int64(BatchGetAssetPropertyAggregatesMaxResults),
 		NextToken:  getNextToken(query.BaseQuery),
 	}
 }

--- a/pkg/sitewise/api/property_history_batch.go
+++ b/pkg/sitewise/api/property_history_batch.go
@@ -15,6 +15,7 @@ import (
 // The front end component should ensure that both cannot be sent at the same time by the user.
 // If an invalid combo of assetId/propertyId/propertyAlias are sent to the API, an exception will be returned.
 // The Framer consumer should bubble up that error to the user.
+// `query.MaxDataPoints` is ignored and it always requests with the maximum number of data points the SiteWise API can support
 func historyBatchQueryToInput(query models.AssetPropertyValueQuery) *iotsitewise.BatchGetAssetPropertyValueHistoryInput {
 
 	var (
@@ -26,10 +27,6 @@ func historyBatchQueryToInput(query models.AssetPropertyValueQuery) *iotsitewise
 	}
 
 	from, to := util.TimeRangeToUnix(query.TimeRange)
-
-	if query.MaxDataPoints < 1 || query.MaxDataPoints > 20000 {
-		query.MaxDataPoints = 20000
-	}
 
 	entries := make([]*iotsitewise.BatchGetAssetPropertyValueHistoryEntry, 0)
 
@@ -62,8 +59,9 @@ func historyBatchQueryToInput(query models.AssetPropertyValueQuery) *iotsitewise
 	}
 
 	return &iotsitewise.BatchGetAssetPropertyValueHistoryInput{
-		Entries:    entries,
-		MaxResults: aws.Int64(query.MaxDataPoints),
+		Entries: entries,
+		// performance: hardcoded to fetch the maximum number of data points
+		MaxResults: aws.Int64(BatchGetAssetPropertyValueHistoryMaxResults),
 		NextToken:  getNextToken(query.BaseQuery),
 	}
 }


### PR DESCRIPTION
…ints

<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

Grafana has a default behavior to set query's `maxDataPoints`  to a somewhat low number (compares to the SiteWise APIs maximum), and causes unnecessary pagination for queries with high response data points. It creates unnecessary latency and request (TPS) load to the server.

For example, for 6 hour time range - the `maxDataPoints` is auto set to `~500`, and requires **~50 request** for 6 hours of 1 second data points = 6hr*60min/hr*60sec/min / 432maxDataPoints/request.

This PR updates the batch APIs queries to request for maximum number of datapoints the SiteWise APIs can support for a better UX.
- BatchGetAssetPropertyValueHistoryMaxResults of 20000
- BatchGetAssetPropertyAggregatesMaxResults of 4000

Before this PR - `GetPropertyValueHistory` for 6 hr took ~10 seconds:

https://github.com/grafana/iot-sitewise-datasource/assets/50635800/134cd459-e7d3-451c-b3a6-b331360f802b

After this PR - `GetPropertyValueHistory` for 6 hr took ~1.5 seconds:

https://github.com/grafana/iot-sitewise-datasource/assets/50635800/e74a527e-6b5a-4ec2-8d98-079cc8b1a7b7


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: