### PR TITLE
Fix e2e tests

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -62,6 +62,7 @@
     "errgroup",
     "ectx",
     "reqs",
-    "struct"
+    "struct",
+    "combobox"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@grafana/e2e": "10.2.0",
     "@grafana/e2e-selectors": "10.2.0",
     "@grafana/eslint-config": "^6.0.0",
-    "@grafana/plugin-e2e": "^0.18.0",
+    "@grafana/plugin-e2e": "^1.3.1",
     "@grafana/runtime": "10.2.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@grafana/ui": "10.2.0",

--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -2,7 +2,11 @@ import { test, expect, ReadProvisionedDataSourceArgs, DataSourceSettings } from 
 import { SitewiseOptions, SitewiseSecureJsonData } from '../src/types';
 
 test.describe('ConfigEditor', () => {
-  test('invalid credentials should return a 400 status code', async ({ createDataSourceConfigPage, page }) => {
+  test('invalid credentials should return a 400 status code', async ({
+    createDataSourceConfigPage,
+    page,
+    selectors,
+  }) => {
     // create a new datasource and navigate to config page
     const configPage = await createDataSourceConfigPage({ type: 'grafana-iot-sitewise-datasource' });
 
@@ -11,8 +15,8 @@ test.describe('ConfigEditor', () => {
     await page.keyboard.press('Enter');
     await page.getByLabel('Access Key ID').fill('bad1credentials');
     await page.getByLabel('Secret Access Key').fill('very-bad-credentials');
-    await page.getByLabel('Default Region').fill('us-east-1');
-    await page.keyboard.press('Enter');
+    await page.getByRole('combobox', { name: 'Default Region' }).click();
+    await configPage.getByGrafanaSelector(selectors.components.Select.option).getByText('us-east-1').click();
 
     // click save and test
     const response = await configPage.saveAndTest();
@@ -31,6 +35,7 @@ test.describe('ConfigEditor', () => {
     createDataSourceConfigPage,
     readProvisionedDataSource,
     page,
+    selectors,
   }) => {
     const { accessKey, secretKey } = await getTestCredentials(readProvisionedDataSource);
 
@@ -42,8 +47,8 @@ test.describe('ConfigEditor', () => {
     await page.keyboard.press('Enter');
     await page.getByLabel('Access Key ID').fill(accessKey);
     await page.getByLabel('Secret Access Key').fill(secretKey);
-    await page.getByLabel('Default Region').fill('us-east-1');
-    await page.keyboard.press('Enter');
+    await page.getByRole('combobox', { name: 'Default Region' }).click();
+    await configPage.getByGrafanaSelector(selectors.components.Select.option).getByText('us-east-1').click();
 
     // click save and test
     const response = await configPage.saveAndTest();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,10 +2176,10 @@
     ua-parser-js "^1.0.32"
     web-vitals "^3.1.1"
 
-"@grafana/plugin-e2e@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@grafana/plugin-e2e/-/plugin-e2e-0.18.0.tgz#6ea180fb90047d2421352b3348e6a5a8af722fba"
-  integrity sha512-sxSkZLO4XzniUbZmMwzMCSOk+1oixTDiPYRRZYSEvIr7bsgomUcPeOM6thjSKMIMn9eqnBTavnNOAX4c8N5+PA==
+"@grafana/plugin-e2e@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@grafana/plugin-e2e/-/plugin-e2e-1.3.1.tgz#06d885f9ad84eb8a90cc5b83bce59a941baad2ce"
+  integrity sha512-H+ENMLm0JRsLtAPhUdouYGCMwj/oblZeCre7E2OHnISLEm2dTJ282lUL5vzXiOAQMw6Nd4oYMfUmBhbo+IIplA==
   dependencies:
     semver "^7.5.4"
     uuid "^9.0.1"


### PR DESCRIPTION
E2E tests are failing on the latest grafana-dev image. The Default Region selector wasn't able to enter `us-east-1` so there would be an error when trying to use `ap-east-1` which is an opt-in region. Not entirely sure what changed with how playwright interacts with the select element, but using the [recommended way to interact with select elements](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/selecting-elements#select-field) fixes it.

The changes to use `inputId` for `<Select>` components are in [this PR in `grafana-aws-sdk-react`](https://github.com/grafana/grafana-aws-sdk-react/pull/85)

Fixes: #317