### PR TITLE
chore: added cache to store/refresh relative range queries.

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -63,6 +63,7 @@
     "ectx",
     "reqs",
     "struct",
-    "combobox"
+    "combobox",
+    "Cacheable"
   ]
 }

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -5,20 +5,24 @@ import {
   DataQueryRequest,
   DataFrame,
   MetricFindValue,
+  LoadingState,
 } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
 import { SitewiseCache } from 'sitewiseCache';
 import { SitewiseQuery, SitewiseOptions, isPropertyQueryType } from './types';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { frameToMetricFindValues } from 'utils';
 import { SitewiseVariableSupport } from 'variables';
 import { SitewiseQueryPaginator } from 'SiteWiseQueryPaginator';
+import { RelativeRangeCache } from 'RelativeRangeRequestCache/RelativeRangeCache';
 
 export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOptions> {
   // Easy access for QueryEditor
   readonly options: SitewiseOptions;
   private cache = new Map<string, SitewiseCache>();
+  private relativeRangeCache = new RelativeRangeCache();
 
   constructor(instanceSettings: DataSourceInstanceSettings<SitewiseOptions>) {
     super(instanceSettings);
@@ -141,12 +145,24 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
   }
 
   query(request: DataQueryRequest<SitewiseQuery>): Observable<DataQueryResponse> {
+    const cachedInfo = request.range != null ? this.relativeRangeCache.get(request) : undefined;
+
     return new SitewiseQueryPaginator({
-      request,
+      request: cachedInfo?.refreshingRequest || request,
       queryFn: (request: DataQueryRequest<SitewiseQuery>) => {
         return super.query(request).toPromise();
       },
-    }).toObservable();
+      cachedResponse: cachedInfo?.cachedResponse,
+    }).toObservable().pipe(
+      // Cache the last (done) response
+      tap({
+        next: (response) => {
+          if (response.state === LoadingState.Done) {
+            this.relativeRangeCache.set(request, response);
+          }
+        },
+      },)
+    );
   }
 }
 

--- a/src/RelativeRangeRequestCache/RelativeRangeCache.test.ts
+++ b/src/RelativeRangeRequestCache/RelativeRangeCache.test.ts
@@ -1,0 +1,482 @@
+import { FieldType, LoadingState, dateTime } from '@grafana/data';
+import { RelativeRangeCache } from 'RelativeRangeRequestCache/RelativeRangeCache';
+import { QueryType, SiteWiseTimeOrder } from 'types';
+import { parseSiteWiseRequestCacheId } from './cacheIdUtils';
+
+describe('RelativeRangeCache', () => {
+  const requestId = 'mock-request-id';
+  const range = {
+    from: dateTime('2024-05-28T00:00:00Z'),
+    to: dateTime('2024-05-28T01:00:00Z'),
+    raw: {
+      from: 'now-1h',
+      to: 'now'
+      ,
+    }
+  };
+
+  const request = {
+    requestId,
+    interval: '5s',
+    intervalMs: 5000,
+    range,
+    scopedVars: {},
+    targets: [
+      {
+        refId: 'A',
+        queryType: QueryType.PropertyValueHistory,
+      },
+      {
+        refId: 'B',
+        queryType: QueryType.DescribeAsset,
+      },
+    ],
+    timezone: 'browser',
+    app: 'dashboard',
+    startTime: 1716858000000,
+  };
+
+  describe('get()', () => {
+    it('returns undefined when there is no cached response', () => {
+      const cache = new RelativeRangeCache();
+
+      expect(cache.get(request)).toBeUndefined();
+    });
+
+    it('returns starting cached data and time series query to fetch', () => {
+      const cachedQueryInfo = [
+        {
+          query: {
+            queryType: QueryType.PropertyValueHistory,
+            refId: 'A',
+          },
+          dataFrame: {
+            name: 'Demo Turbine Asset 1',
+            refId: 'A',
+            fields: [
+              {
+                name: 'time',
+                type: FieldType.time,
+                config: {},
+                values: [
+                  1716854400000,  // 2024-05-28T00:00:00Z
+                  1716854400001,  // 2024-05-28T00:15:00Z + 1ms
+                  1716855300000,  // 2024-05-28T00:15:00Z
+                  1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+                  1716857100000,  // 2024-05-28T00:45:00Z
+                  1716857100001,  // 2024-05-28T00:45:00Z + 1ms
+                ],
+              },
+              {
+                name: 'RotationsPerSecond',
+                type: FieldType.number,
+                config: {
+                  unit: 'RPS'
+                },
+                values: [0,1,2,3,4,5],
+              },
+            ],
+            length: 6
+          },
+        },
+        {
+          query: {
+            queryType: QueryType.ListAssociatedAssets,
+            refId: 'B',
+          },
+          dataFrame: {
+            name: 'child',
+            refId: 'B',
+            fields: [
+              {
+                  name: 'name',
+                  type: FieldType.string,
+                  config: {},
+                  values: [
+                    'child'
+                  ],
+              },
+            ],
+            length: 1
+          },
+        }
+      ];
+      const expectedDataFrames = [
+        {
+          name: 'Demo Turbine Asset 1',
+          refId: 'A',
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              config: {},
+              values: [
+                1716854400001,  // 2024-05-28T00:15:00Z + 1ms
+                1716855300000,  // 2024-05-28T00:15:00Z
+                1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+                1716857100000,  // 2024-05-28T00:45:00Z
+              ],
+            },
+            {
+              name: 'RotationsPerSecond',
+              type: FieldType.number,
+              config: {
+                unit: 'RPS'
+              },
+              values: [1,2,3,4],
+            },
+          ],
+          length: 4
+        },
+        {
+          name: 'child',
+          refId: 'B',
+          fields: [
+            {
+                name: 'name',
+                type: FieldType.string,
+                config: {},
+                values: [
+                  'child'
+                ],
+            },
+          ],
+          length: 1
+        },
+      ];
+
+      const cacheData = {
+        [parseSiteWiseRequestCacheId(request)]: {
+          queries: cachedQueryInfo,
+          range,
+        },
+      };
+      const cache = new RelativeRangeCache(new Map(Object.entries(cacheData)));
+
+      const cacheResult = cache.get(request);
+
+      expect(cacheResult).toBeDefined()
+      expect(cacheResult?.cachedResponse).toEqual({
+        start: {
+          data: expectedDataFrames,
+          key: requestId,
+          state: LoadingState.Streaming,
+        },
+        end: {
+          data: [],
+          key: requestId,
+          state: LoadingState.Streaming,
+        },
+      });
+      expect(cacheResult?.refreshingRequest).toEqual({
+        ...request,
+        targets: [
+          {
+            ...request.targets[0],  // only time series query
+          },
+        ],
+        range: {
+          from: dateTime(1716857100000),  // '2024-05-28T01:45:00Z'
+          to: dateTime('2024-05-28T01:00:00Z'),
+          raw: {
+            from: 'now-1h',
+            to: 'now'
+            ,
+          }
+        }
+      })
+    });
+
+    it('returns ending cached data and time series query to fetch', () => {
+      const requestDescending = {
+        requestId,
+        interval: '5s',
+        intervalMs: 5000,
+        range,
+        scopedVars: {},
+        targets: [
+          {
+            refId: 'A',
+            queryType: QueryType.PropertyValueHistory,
+            timeOrdering: SiteWiseTimeOrder.DESCENDING,
+          },
+          {
+            refId: 'B',
+            queryType: QueryType.DescribeAsset,
+          },
+        ],
+        timezone: 'browser',
+        app: 'dashboard',
+        startTime: 1716858000000,
+      };
+      const cachedQueryInfoDescending = [
+        {
+          query: {
+            queryType: QueryType.PropertyValueHistory,
+            refId: 'A',
+            timeOrdering: SiteWiseTimeOrder.DESCENDING,
+          },
+          dataFrame: {
+            name: 'Demo Turbine Asset 1',
+            refId: 'A',
+            fields: [
+              {
+                name: 'time',
+                type: FieldType.time,
+                config: {},
+                values: [
+                  1716857100001,  // 2024-05-28T00:45:00Z + 1ms
+                  1716857100000,  // 2024-05-28T00:45:00Z
+                  1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+                  1716855300000,  // 2024-05-28T00:15:00Z
+                  1716854400001,  // 2024-05-28T00:15:00Z + 1ms
+                  1716854400000,  // 2024-05-28T00:00:00Z
+                ],
+              },
+              {
+                name: 'RotationsPerSecond',
+                type: FieldType.number,
+                config: {
+                  unit: 'RPS'
+                },
+                values: [5,4,3,2,1,0],
+              },
+            ],
+            length: 6
+          },
+        },
+        {
+          query: {
+            queryType: QueryType.ListAssociatedAssets,
+            refId: 'B',
+          },
+          dataFrame: {
+            name: 'child',
+            refId: 'B',
+            fields: [
+              {
+                  name: 'name',
+                  type: FieldType.string,
+                  config: {},
+                  values: [
+                    'child'
+                  ],
+              },
+            ],
+            length: 1
+          },
+        }
+      ];
+      const expectedStartDataFrames = [
+        {
+          name: 'Demo Turbine Asset 1',
+          refId: 'A',
+          fields: [],
+          length: 0,
+        },
+        {
+          name: 'child',
+          refId: 'B',
+          fields: [
+            {
+                name: 'name',
+                type: FieldType.string,
+                config: {},
+                values: [
+                  'child'
+                ],
+            },
+          ],
+          length: 1
+        }
+      ];
+      const expectedEndingDataFrames = [
+        {
+          name: 'Demo Turbine Asset 1',
+          refId: 'A',
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              config: {},
+              values: [
+                1716857100000,  // 2024-05-28T00:45:00Z
+                1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+                1716855300000,  // 2024-05-28T00:15:00Z
+                1716854400001,  // 2024-05-28T00:15:00Z + 1ms
+              ],
+            },
+            {
+              name: 'RotationsPerSecond',
+              type: FieldType.number,
+              config: {
+                unit: 'RPS'
+              },
+              values: [4,3,2,1],
+            },
+          ],
+          length: 4
+        }
+      ];
+      
+      const cacheData = {
+        [parseSiteWiseRequestCacheId(requestDescending)]: {
+          queries: cachedQueryInfoDescending,
+          range,
+        },
+      };
+      const cache = new RelativeRangeCache(new Map(Object.entries(cacheData)));
+
+      const cacheResult = cache.get(requestDescending);
+
+      expect(cacheResult).toBeDefined()
+      expect(cacheResult?.cachedResponse).toEqual({
+        start: {
+          data: expectedStartDataFrames,
+          key: requestId,
+          state: LoadingState.Streaming,
+        },
+        end: {
+          data: expectedEndingDataFrames,
+          key: requestId,
+          state: LoadingState.Streaming,
+        },
+      });
+      expect(cacheResult?.refreshingRequest).toEqual({
+        ...requestDescending,
+        targets: [
+          {
+            ...requestDescending.targets[0],  // only time series query
+          },
+        ],
+        range: {
+          from: dateTime(1716857100000),  // '2024-05-28T01:45:00Z'
+          to: dateTime('2024-05-28T01:00:00Z'),
+          raw: {
+            from: 'now-1h',
+            to: 'now'
+            ,
+          }
+        }
+      })
+    });
+  });
+
+  describe('set()', () => {
+    const cachedQueryInfo = [
+      {
+        query: {
+          queryType: QueryType.PropertyValueHistory,
+          refId: 'A',
+        },
+        dataFrame: {
+          name: 'Demo Turbine Asset 1',
+          refId: 'A',
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              config: {},
+              values: [
+                1716854400001,  // 2024-05-28T00:15:00Z + 1ms
+                1716855300000,  // 2024-05-28T00:15:00Z
+                1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+                1716857100000,  // 2024-05-28T00:45:00Z
+              ],
+            },
+            {
+              name: 'RotationsPerSecond',
+              type: FieldType.number,
+              config: {
+                unit: 'RPS'
+              },
+              values: [1,2,3,4],
+            },
+          ],
+          length: 4
+        },
+      },
+      {
+        query: {
+          queryType: QueryType.DescribeAsset,
+          refId: 'B',
+        },
+        dataFrame: {
+          name: 'child',
+          refId: 'B',
+          fields: [
+            {
+                name: 'name',
+                type: FieldType.string,
+                config: {},
+                values: [
+                  'child'
+                ],
+            },
+          ],
+          length: 1
+        },
+      }
+    ];  
+    const expectedDataFrames = [
+      {
+        name: 'Demo Turbine Asset 1',
+        refId: 'A',
+        fields: [
+          {
+            name: 'time',
+            type: FieldType.time,
+            config: {},
+            values: [
+              1716854400001,  // 2024-05-28T00:15:00Z + 1ms
+              1716855300000,  // 2024-05-28T00:15:00Z
+              1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+              1716857100000,  // 2024-05-28T00:45:00Z
+            ],
+          },
+          {
+            name: 'RotationsPerSecond',
+            type: FieldType.number,
+            config: {
+              unit: 'RPS'
+            },
+            values: [1,2,3,4],
+          },
+        ],
+        length: 4
+      },
+      {
+        name: 'child',
+        refId: 'B',
+        fields: [
+          {
+              name: 'name',
+              type: FieldType.string,
+              config: {},
+              values: [
+                'child'
+              ],
+          },
+        ],
+        length: 1
+      },
+    ];
+
+    const cacheData = {
+      [parseSiteWiseRequestCacheId(request)]: {
+        queries: cachedQueryInfo,
+        range,
+      },
+    };
+    const expectedCacheMap = new Map(Object.entries(cacheData))
+
+    const cacheMap = new Map();
+    const cache = new RelativeRangeCache(cacheMap);
+
+    cache.set(request, {
+      data: expectedDataFrames
+    });
+
+    expect(cacheMap).toEqual(expectedCacheMap);
+  });
+});

--- a/src/RelativeRangeRequestCache/RelativeRangeCache.test.ts
+++ b/src/RelativeRangeRequestCache/RelativeRangeCache.test.ts
@@ -1,7 +1,7 @@
 import { FieldType, LoadingState, dateTime } from '@grafana/data';
 import { RelativeRangeCache } from 'RelativeRangeRequestCache/RelativeRangeCache';
 import { QueryType, SiteWiseTimeOrder } from 'types';
-import { parseSiteWiseRequestCacheId } from './cacheIdUtils';
+import { generateSiteWiseRequestCacheId } from './cacheIdUtils';
 
 describe('RelativeRangeCache', () => {
   const requestId = 'mock-request-id';
@@ -146,7 +146,7 @@ describe('RelativeRangeCache', () => {
       ];
 
       const cacheData = {
-        [parseSiteWiseRequestCacheId(request)]: {
+        [generateSiteWiseRequestCacheId(request)]: {
           queries: cachedQueryInfo,
           range,
         },
@@ -320,7 +320,7 @@ describe('RelativeRangeCache', () => {
       ];
       
       const cacheData = {
-        [parseSiteWiseRequestCacheId(requestDescending)]: {
+        [generateSiteWiseRequestCacheId(requestDescending)]: {
           queries: cachedQueryInfoDescending,
           range,
         },
@@ -463,7 +463,7 @@ describe('RelativeRangeCache', () => {
     ];
 
     const cacheData = {
-      [parseSiteWiseRequestCacheId(request)]: {
+      [generateSiteWiseRequestCacheId(request)]: {
         queries: cachedQueryInfo,
         range,
       },

--- a/src/RelativeRangeRequestCache/RelativeRangeCache.ts
+++ b/src/RelativeRangeRequestCache/RelativeRangeCache.ts
@@ -47,6 +47,10 @@ export class RelativeRangeCache {
       range,
     } = request;
 
+    if (!RelativeRangeCache.isClientCacheEnabled(targets)) {
+      return;
+    }
+
     if (!isCacheableTimeRange(range)) {
       return;
     }
@@ -96,7 +100,11 @@ export class RelativeRangeCache {
    * 4. otherwise, it returns undefined
    */
   get(request: DataQueryRequest<SitewiseQuery>): RelativeRangeCacheInfo | undefined {
-    const { range: requestRange } = request;
+    const { range: requestRange, targets } = request;
+
+    if (!RelativeRangeCache.isClientCacheEnabled(targets)) {
+      return undefined;
+    }
 
     if (!isCacheableTimeRange(request.range)) {
       return undefined;
@@ -109,6 +117,11 @@ export class RelativeRangeCache {
     }
 
     return RelativeRangeCache.parseCacheInfo(cachedDataInfo, request);
+  }
+
+  private static isClientCacheEnabled(targets: DataQueryRequest<SitewiseQuery>['targets']) {
+    // default to enabled unless any query explicitly disables clientCache
+    return !targets.some((target) => target.clientCache === false);
   }
 
   /**

--- a/src/RelativeRangeRequestCache/RelativeRangeCache.ts
+++ b/src/RelativeRangeRequestCache/RelativeRangeCache.ts
@@ -1,0 +1,167 @@
+import { DataFrame, DataQueryRequest, DataQueryResponse, LoadingState, TimeRange } from '@grafana/data';
+import { isTimeRangeCoveringStart } from 'timeRangeUtils';
+import { SitewiseQuery } from 'types';
+import { RequestCacheId, parseSiteWiseRequestCacheId } from './cacheIdUtils';
+import { CachedQueryInfo, TIME_SERIES_QUERY_TYPES } from './types';
+import { trimCachedQueryDataFramesAtStart, trimCachedQueryDataFramesEnding } from './dataFrameUtils';
+import { getRefreshRequestRange, isCacheableTimeRange } from './timeRangeUtils';
+
+interface DataFrameCacheInfo {
+  queries: CachedQueryInfo[],
+  range: TimeRange;
+}
+
+export interface RelativeRangeCacheInfo {
+  cachedResponse: {
+    start: DataQueryResponse;
+    end: DataQueryResponse;
+  };
+  refreshingRequest: DataQueryRequest<SitewiseQuery>;
+}
+
+/**
+ * Cache for relative range queries.
+ * It caches the start and end of the range for each query.
+ *
+ * @internal
+ * `RelativeRangeCache` uses an private map `responseDataMap` to track a history of the relative range requests and their data frame responses.
+ */
+export class RelativeRangeCache {
+  constructor(private responseDataMap: Map<RequestCacheId, DataFrameCacheInfo> = new Map<RequestCacheId, DataFrameCacheInfo>()) {}
+
+  /**
+   * Set the cache for the given query and response.
+   * @param request The query used to get the response
+   * @param response The response to set the cache for
+   * 
+   * @internal
+   * This method sets a request/response pair to `responseDataMap`, it performs the followings:
+   * 1. validates the `request` is a relative time range and has data 15 minute ago (data within 15 minute are always refreshed)
+   * 2. creates a unique cache id for the request
+   * 3. creates a `DataFrameCacheInfo` object with the `queries` and `range` from the `response`
+   * 4. sets the `DataFrameCacheInfo` object to the `responseDataMap` using the cache id as the key
+   */
+  set(request: DataQueryRequest<SitewiseQuery>, response: DataQueryResponse) {
+    const {
+      targets,
+      range,
+    } = request;
+
+    if (!isCacheableTimeRange(range)) {
+      return;
+    }
+
+    const requestCacheId = parseSiteWiseRequestCacheId(request);
+    
+    const queryIdMap = new Map(targets.map(q => [q.refId, q]));
+
+    try {
+      const queries = response.data.map((dataFrame: DataFrame) => {
+        if (dataFrame.refId == null) {
+          console.error('Response data frame without a refId, dataFrame: ', dataFrame);
+          throw new Error('Response data frame without a refId!');
+        }
+
+        const query = queryIdMap.get(dataFrame.refId);
+        if (query == null){
+          console.error('Response data frame without a corresponding request target, dataFrame: ', dataFrame);
+          throw new Error('Response data frame without a corresponding request target!');
+        }
+
+        return {
+          query,
+          dataFrame: dataFrame,
+        };
+      });
+
+      this.responseDataMap.set(requestCacheId, {
+        queries,
+        range,
+      });
+    } catch (error) {
+      // NOOP
+    }
+  }
+
+  /**
+   * Get the cached response for the given request.
+   * @param request The request to get the cached response for
+   * @returns The cached response if found, undefined otherwise
+   * 
+   * @internal
+   * This method gets the cached response for the given request:
+   * 1. validates the `request` is a relative time range and has data 15 minute ago (data within 15 minute are always refreshed)
+   * 2. looks up the cached data for the request in `responseDataMap` using the cache id
+   * 3. if the cached data is found and covers the request range, it trims the data point till the refreshing request, and then returns the cached data and the refreshing request
+   * 4. otherwise, it returns undefined
+   */
+  get(request: DataQueryRequest<SitewiseQuery>): RelativeRangeCacheInfo | undefined {
+    const { range: requestRange } = request;
+
+    if (!isCacheableTimeRange(request.range)) {
+      return undefined;
+    }
+
+    const cachedDataInfo = this.lookupCachedData(request);
+    
+    if (cachedDataInfo == null || !isTimeRangeCoveringStart(cachedDataInfo.range, requestRange)) {
+      return undefined;
+    }
+
+    return RelativeRangeCache.parseCacheInfo(cachedDataInfo, request);
+  }
+
+  /**
+   * Lookup cached data for the given request.
+   * @param request DataQueryRequest<SitewiseQuery> request to lookup cached data for
+   * @returns Cached data info if found, undefined otherwise
+   */
+  private lookupCachedData(request: DataQueryRequest<SitewiseQuery>) {
+    const requestCacheId = parseSiteWiseRequestCacheId(request);
+    const cachedDataInfo = this.responseDataMap.get(requestCacheId);
+    
+    return cachedDataInfo;
+  }
+
+  private static parseCacheInfo(cachedDataInfo: DataFrameCacheInfo, request: DataQueryRequest<SitewiseQuery>) {
+    const { range: requestRange, requestId } = request;
+
+    const refreshingRequestRange = getRefreshRequestRange(requestRange, cachedDataInfo.range);
+    const refreshingRequest = RelativeRangeCache.getRefreshingRequest(request, refreshingRequestRange);
+
+    const cacheRange = {
+      from: requestRange.from.valueOf(),
+      to: refreshingRequestRange.from.valueOf(),
+    };
+    const cachedDataFrames = trimCachedQueryDataFramesAtStart(cachedDataInfo.queries, cacheRange);
+    const cachedDataFramesEnding = trimCachedQueryDataFramesEnding(cachedDataInfo.queries, cacheRange);
+
+    return {
+      cachedResponse: {
+        start: {
+          data: cachedDataFrames,
+          key: requestId,
+          state: LoadingState.Streaming,
+        },
+        end: {
+          data: cachedDataFramesEnding,
+          key: requestId,
+          state: LoadingState.Streaming,
+        },
+      },
+      refreshingRequest,
+    };
+  }
+
+  private static getRefreshingRequest(request: DataQueryRequest<SitewiseQuery>, range: TimeRange) {
+    const {
+      targets,
+    } = request;
+    
+    return {
+      ...request,
+      range,
+      targets: targets.filter(({ queryType }) => TIME_SERIES_QUERY_TYPES.has(queryType)),
+    };
+  }
+}

--- a/src/RelativeRangeRequestCache/RelativeRangeCache.ts
+++ b/src/RelativeRangeRequestCache/RelativeRangeCache.ts
@@ -1,7 +1,7 @@
 import { DataFrame, DataQueryRequest, DataQueryResponse, LoadingState, TimeRange } from '@grafana/data';
 import { isTimeRangeCoveringStart } from 'timeRangeUtils';
 import { SitewiseQuery } from 'types';
-import { RequestCacheId, parseSiteWiseRequestCacheId } from './cacheIdUtils';
+import { RequestCacheId, generateSiteWiseRequestCacheId } from './cacheIdUtils';
 import { CachedQueryInfo, TIME_SERIES_QUERY_TYPES } from './types';
 import { trimCachedQueryDataFramesAtStart, trimCachedQueryDataFramesEnding } from './dataFrameUtils';
 import { getRefreshRequestRange, isCacheableTimeRange } from './timeRangeUtils';
@@ -51,7 +51,7 @@ export class RelativeRangeCache {
       return;
     }
 
-    const requestCacheId = parseSiteWiseRequestCacheId(request);
+    const requestCacheId = generateSiteWiseRequestCacheId(request);
     
     const queryIdMap = new Map(targets.map(q => [q.refId, q]));
 
@@ -117,7 +117,7 @@ export class RelativeRangeCache {
    * @returns Cached data info if found, undefined otherwise
    */
   private lookupCachedData(request: DataQueryRequest<SitewiseQuery>) {
-    const requestCacheId = parseSiteWiseRequestCacheId(request);
+    const requestCacheId = generateSiteWiseRequestCacheId(request);
     const cachedDataInfo = this.responseDataMap.get(requestCacheId);
     
     return cachedDataInfo;

--- a/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
@@ -1,5 +1,5 @@
 import { QueryType, SiteWiseQuality, SiteWiseResolution, SiteWiseResponseFormat, SiteWiseTimeOrder } from 'types';
-import { parseSiteWiseQueriesCacheId, parseSiteWiseRequestCacheId } from './cacheIdUtils';
+import { generateSiteWiseQueriesCacheId, generateSiteWiseRequestCacheId } from './cacheIdUtils';
 import { dateTime } from '@grafana/data';
 import { SitewiseQueriesUnion } from './types';
 
@@ -30,9 +30,9 @@ function createSiteWiseQuery(id: number): SitewiseQueriesUnion {
   };
 }
 
-describe('parseSiteWiseQueriesCacheId()', () => {
+describe('generateSiteWiseQueriesCacheId()', () => {
   it('parses SiteWise Queries into cache Id', () => {
-    const actualId = parseSiteWiseQueriesCacheId([createSiteWiseQuery(1), createSiteWiseQuery(2)]);
+    const actualId = generateSiteWiseQueriesCacheId([createSiteWiseQuery(1), createSiteWiseQuery(2)]);
     const expectedId = JSON.stringify([
       '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL"]',
       '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL"]'
@@ -68,8 +68,8 @@ describe('parseSiteWiseQueriesCacheId()', () => {
       queryType: QueryType.PropertyValue,
     };
 
-    const order1 = parseSiteWiseQueriesCacheId([query2, query1]);
-    const order2 = parseSiteWiseQueriesCacheId([query1, query2]);
+    const order1 = generateSiteWiseQueriesCacheId([query2, query1]);
+    const order2 = generateSiteWiseQueriesCacheId([query1, query2]);
 
     expect(order1).toEqual(order2);
   });
@@ -80,7 +80,7 @@ describe('parseSiteWiseQueriesCacheId()', () => {
       refId: 'A-1',
       queryType: QueryType.ListAssets,
     };
-    const actualId = parseSiteWiseQueriesCacheId([query]);
+    const actualId = generateSiteWiseQueriesCacheId([query]);
     const expectedId = JSON.stringify([
       '["ListAssets",null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]',
     ]);
@@ -89,7 +89,7 @@ describe('parseSiteWiseQueriesCacheId()', () => {
   });
 });
 
-describe('parseSiteWiseRequestCacheId()', () => {
+describe('generateSiteWiseRequestCacheId()', () => {
   it('parses SiteWise Queries into cache Id', () => {
     const request = {
       requestId: 'mock-request-id',
@@ -117,6 +117,6 @@ describe('parseSiteWiseRequestCacheId()', () => {
       ])
     ]);
 
-    expect(parseSiteWiseRequestCacheId(request)).toEqual(expectedId);
+    expect(generateSiteWiseRequestCacheId(request)).toEqual(expectedId);
   });
 });

--- a/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
@@ -1,0 +1,122 @@
+import { QueryType, SiteWiseQuality, SiteWiseResolution, SiteWiseResponseFormat, SiteWiseTimeOrder } from 'types';
+import { parseSiteWiseQueriesCacheId, parseSiteWiseRequestCacheId } from './cacheIdUtils';
+import { dateTime } from '@grafana/data';
+import { SitewiseQueriesUnion } from './types';
+
+function createSiteWiseQuery(id: number): SitewiseQueriesUnion {
+  return {
+    queryType: QueryType.PropertyValueHistory,
+    region: 'us-west-2',
+    responseFormat: SiteWiseResponseFormat.Table,
+    assetId: `mock-asset-id-${id}`,
+    assetIds: [`mock-asset-id-${id}`],
+    propertyId: `mock-property-id-${id}`,
+    propertyAlias: `mock-property-alias-${id}`,
+    quality: SiteWiseQuality.ANY,
+    resolution: SiteWiseResolution.Auto,
+    lastObservation: true,
+    flattenL4e: true,
+    maxPageAggregations: 1000,
+    datasource: {
+      type: 'grafana-iot-sitewise-datasource',
+      uid: 'mock-datasource-uid'
+    },
+    refId: `A-${id}`,
+    timeOrdering: SiteWiseTimeOrder.ASCENDING,
+    loadAllChildren: true,
+    hierarchyId: `mock-hierarchy-${id}`,
+    modelId: `mock-model-${id}`,
+    filter: 'ALL',
+  };
+}
+
+describe('parseSiteWiseQueriesCacheId()', () => {
+  it('parses SiteWise Queries into cache Id', () => {
+    const actualId = parseSiteWiseQueriesCacheId([createSiteWiseQuery(1), createSiteWiseQuery(2)]);
+    const expectedId = JSON.stringify([
+      '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL"]',
+      '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL"]'
+    ]);
+
+    expect(actualId).toEqual(expectedId);
+  });
+
+  it('parses SiteWise Query properties in a stable fashion (disregard of the order queries and queries\' properties are added)', () => {
+    // Reversed order of properties
+    const query1: SitewiseQueriesUnion = {
+      timeOrdering: SiteWiseTimeOrder.ASCENDING,
+      refId: 'A-1',
+      datasource: {
+        uid: 'mock-datasource-uid',
+        type: 'grafana-iot-sitewise-datasource',
+      },
+      maxPageAggregations: 1000,
+      flattenL4e: true,
+      lastObservation: true,
+      resolution: SiteWiseResolution.Auto,
+      quality: SiteWiseQuality.ANY,
+      propertyAlias: 'mock-property-alias-1',
+      propertyId: 'mock-property-id-1',
+      assetIds: ['mock-asset-id-1'],
+      assetId: 'mock-asset-id-1',
+      responseFormat: SiteWiseResponseFormat.Table,
+      region: 'us-west-2',
+      queryType: QueryType.PropertyValueHistory,
+    };
+    const query2 = {
+      ...query1,
+      queryType: QueryType.PropertyValue,
+    };
+
+    const order1 = parseSiteWiseQueriesCacheId([query2, query1]);
+    const order2 = parseSiteWiseQueriesCacheId([query1, query2]);
+
+    expect(order1).toEqual(order2);
+  });
+
+  it('parses SiteWise Query with only required properties provided', () => {
+    // With only required properties
+    const query: SitewiseQueriesUnion = {
+      refId: 'A-1',
+      queryType: QueryType.ListAssets,
+    };
+    const actualId = parseSiteWiseQueriesCacheId([query]);
+    const expectedId = JSON.stringify([
+      '["ListAssets",null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]',
+    ]);
+
+    expect(actualId).toEqual(expectedId);
+  });
+});
+
+describe('parseSiteWiseRequestCacheId()', () => {
+  it('parses SiteWise Queries into cache Id', () => {
+    const request = {
+      requestId: 'mock-request-id',
+      interval: '5s',
+      intervalMs: 5000,
+      range: {
+        from: dateTime('2024-05-28T00:00:00Z'),
+        to: dateTime('2024-05-28T01:00:00Z'),
+        raw: {
+          from: 'now-15m',
+          to: 'now'
+        ,}
+      },
+      scopedVars: {},
+      targets: [createSiteWiseQuery(1), createSiteWiseQuery(2)],
+      timezone: 'browser',
+      app: 'dashboard',
+      startTime: 1716858000000,
+    };
+    const expectedId = JSON.stringify([
+      'now-15m',
+      JSON.stringify([
+        '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL"]',
+        '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL"]'
+      ])
+    ]);
+
+    expect(parseSiteWiseRequestCacheId(request)).toEqual(expectedId);
+  });
+});

--- a/src/RelativeRangeRequestCache/cacheIdUtils.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.ts
@@ -3,16 +3,16 @@ import { SitewiseQueriesUnion } from './types';
 
 export type RequestCacheId = string;
 
-export function parseSiteWiseRequestCacheId(request: DataQueryRequest<SitewiseQueriesUnion>): RequestCacheId {
+export function generateSiteWiseRequestCacheId(request: DataQueryRequest<SitewiseQueriesUnion>): RequestCacheId {
   const { targets, range: { raw: { from } } } = request;
 
-  return JSON.stringify([from, parseSiteWiseQueriesCacheId(targets)]);
+  return JSON.stringify([from, generateSiteWiseQueriesCacheId(targets)]);
 }
 
 type QueryCacheId = string;
 
-export function parseSiteWiseQueriesCacheId(queries: SitewiseQueriesUnion[]): QueryCacheId {
-  const cacheIds = queries.map(parseSiteWiseQueryCacheId).sort();
+export function generateSiteWiseQueriesCacheId(queries: SitewiseQueriesUnion[]): QueryCacheId {
+  const cacheIds = queries.map(generateSiteWiseQueryCacheId).sort();
 
   return JSON.stringify(cacheIds);
 }
@@ -20,7 +20,7 @@ export function parseSiteWiseQueriesCacheId(queries: SitewiseQueriesUnion[]): Qu
 /**
  * Parse query to cache id.
  */
-function parseSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId {
+function generateSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId {
   const {
     queryType,
     region,

--- a/src/RelativeRangeRequestCache/cacheIdUtils.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.ts
@@ -1,0 +1,70 @@
+import { DataQueryRequest } from '@grafana/data';
+import { SitewiseQueriesUnion } from './types';
+
+export type RequestCacheId = string;
+
+export function parseSiteWiseRequestCacheId(request: DataQueryRequest<SitewiseQueriesUnion>): RequestCacheId {
+  const { targets, range: { raw: { from } } } = request;
+
+  return JSON.stringify([from, parseSiteWiseQueriesCacheId(targets)]);
+}
+
+type QueryCacheId = string;
+
+export function parseSiteWiseQueriesCacheId(queries: SitewiseQueriesUnion[]): QueryCacheId {
+  const cacheIds = queries.map(parseSiteWiseQueryCacheId).sort();
+
+  return JSON.stringify(cacheIds);
+}
+
+/**
+ * Parse query to cache id.
+ */
+function parseSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId {
+  const {
+    queryType,
+    region,
+    responseFormat,
+    assetId,
+    assetIds,
+    propertyId,
+    propertyAlias,
+    quality,
+    resolution,
+    lastObservation,
+    flattenL4e,
+    maxPageAggregations,
+    datasource,
+    timeOrdering,
+    loadAllChildren,
+    hierarchyId,
+    modelId,
+    filter,
+  } = query;
+
+  /*
+   * Stringify to preserve undefined optional properties
+   * `Undefined` optional properties are preserved as `null`
+   */
+  return JSON.stringify([
+    queryType,
+    region,
+    responseFormat,
+    assetId,
+    assetIds,
+    propertyId,
+    propertyAlias,
+    quality,
+    resolution,
+    lastObservation,
+    flattenL4e,
+    maxPageAggregations,
+    datasource?.type,
+    datasource?.uid,
+    timeOrdering,
+    loadAllChildren,
+    hierarchyId,
+    modelId,
+    filter,
+  ]);
+}

--- a/src/RelativeRangeRequestCache/constants.ts
+++ b/src/RelativeRangeRequestCache/constants.ts
@@ -1,0 +1,2 @@
+// The time range (in minutes) to always request for regardless of cache.
+export const DEFAULT_TIME_SERIES_REFRESH_MINUTES = 15;

--- a/src/RelativeRangeRequestCache/dataFrameUtils.test.ts
+++ b/src/RelativeRangeRequestCache/dataFrameUtils.test.ts
@@ -1,0 +1,358 @@
+import { DataFrame, FieldType, dateTime } from '@grafana/data';
+import { QueryType, SiteWiseTimeOrder } from 'types';
+import { trimCachedQueryDataFramesAtStart, trimCachedQueryDataFramesEnding } from './dataFrameUtils';
+
+describe('trimCachedQueryDataFrames', () => {
+  const absolutionRange = {
+    from: dateTime('2024-05-28T00:00:00Z').valueOf(),
+    to: dateTime('2024-05-28T00:15:00Z').valueOf(),
+  };
+
+  const dataFrame: DataFrame = {
+    name: 'Demo Turbine Asset 1',
+    refId: 'A',
+    fields: [
+      {
+        name: 'time',
+        type: FieldType.time,
+        config: {},
+        values: [
+          1716854400000,  // 2024-05-28T00:00:00Z
+          1716854400001,  // 2024-05-28T00:00:00Z + 1ms
+          1716855300000,  // 2024-05-28T00:15:00Z
+          1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+        ],
+      },
+      {
+        name: 'RotationsPerSecond',
+        type: FieldType.number,
+        config: {
+          unit: 'RPS'
+        },
+        values: [
+          1,
+          2,
+          3,
+          4,
+        ],
+      },
+    ],
+    length: 4
+  };
+
+  const dataFrameDescending: DataFrame = {
+    name: 'Demo Turbine Asset 1',
+    refId: 'A',
+    fields: [
+      {
+        name: 'time',
+        type: FieldType.time,
+        config: {},
+        values: [
+          1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+          1716855300000,  // 2024-05-28T00:15:00Z
+          1716854400001,  // 2024-05-28T00:00:00Z + 1ms
+          1716854400000,  // 2024-05-28T00:00:00Z
+        ],
+      },
+      {
+        name: 'RotationsPerSecond',
+        type: FieldType.number,
+        config: {
+          unit: 'RPS'
+        },
+        values: [4,3,2,1],
+      },
+    ],
+    length: 4
+  };
+
+  it('excludes data of PropertyValue query', () => {
+    const cachedQueryInfo = {
+      query: {
+        queryType: QueryType.PropertyValue,
+        refId: 'A'
+      },
+      dataFrame,
+    };
+    const dataFrames = trimCachedQueryDataFramesAtStart([cachedQueryInfo], absolutionRange);
+
+    expect(dataFrames).toHaveLength(1);
+    expect(dataFrames).toContainEqual({
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [],
+      length: 0,
+    });
+  });
+
+  it.each([
+    QueryType.ListAssetModels,
+    QueryType.ListAssets,
+    QueryType.ListAssociatedAssets,
+    QueryType.ListAssetProperties,
+    QueryType.DescribeAsset,
+  ])('does not modify data of non-time-series type - %s', (queryType: QueryType) => {
+    const cachedQueryInfo = {
+      query: {
+        queryType,
+        refId: 'A'
+      },
+      dataFrame,
+    };
+    const dataFrames = trimCachedQueryDataFramesAtStart([cachedQueryInfo], absolutionRange);
+
+    expect(dataFrames).toHaveLength(1);
+    expect(dataFrames).toContainEqual(dataFrame);
+  });
+
+  it.each([
+    QueryType.PropertyAggregate,
+    QueryType.PropertyInterpolated,
+    QueryType.PropertyValueHistory,
+  ])('trims time series data of time-series type - "%s"', (queryType: QueryType) => {
+    const cachedQueryInfo = {
+      query: {
+        queryType,
+        refId: 'A'
+      },
+      dataFrame,
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [
+            1716854400001,  // +1ms
+            1716855300000,  // 2024-05-28T00:15:00Z
+          ],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [
+            2,
+            3,
+          ],
+        },
+      ],
+      length: 2
+    };
+    const dataFrames = trimCachedQueryDataFramesAtStart([cachedQueryInfo], absolutionRange);
+
+    expect(dataFrames).toHaveLength(1);
+    expect(dataFrames).toContainEqual(expectedDataFrame);
+  });
+
+  it.each([
+    QueryType.PropertyAggregate,
+    QueryType.PropertyInterpolated,
+    QueryType.PropertyValueHistory,
+  ])('trims descending time series data of time-series type - "%s"', (queryType: QueryType) => {
+    const cachedQueryInfo = {
+      query: {
+        queryType,
+        refId: 'A',
+        timeOrdering: SiteWiseTimeOrder.DESCENDING,
+      },
+      dataFrame: dataFrameDescending,
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [
+            1716855300000,  // 2024-05-28T00:15:00Z
+            1716854400001,  // 2024-05-28T00:00:00Z+1ms
+          ],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [3,2],
+        },
+      ],
+      length: 2
+    };
+    const dataFrames = trimCachedQueryDataFramesEnding([cachedQueryInfo], absolutionRange);
+
+    expect(dataFrames).toHaveLength(1);
+    expect(dataFrames).toContainEqual(expectedDataFrame);
+  });
+
+  it('keeps all data when all time values within range', () => {
+    const cachedQueryInfo = {
+      query: {
+        queryType: QueryType.PropertyValueHistory,
+        refId: 'A'
+      },
+      dataFrame: {
+        name: 'Demo Turbine Asset 1',
+        refId: 'A',
+        fields: [
+          {
+            name: 'time',
+            type: FieldType.time,
+            config: {},
+            values: [
+              1716854400001,  // 2024-05-28T00:00:00Z+1ms
+              1716855300000,  // 2024-05-28T00:15:00Z
+            ],
+          },
+          {
+            name: 'RotationsPerSecond',
+            type: FieldType.number,
+            config: {
+              unit: 'RPS'
+            },
+            values: [
+              1,
+              2,
+            ],
+          },
+        ],
+        length: 2
+      },
+    };
+    const dataFrames = trimCachedQueryDataFramesAtStart([cachedQueryInfo], absolutionRange);
+
+    expect(dataFrames).toHaveLength(1);
+    expect(dataFrames).toContainEqual(cachedQueryInfo.dataFrame);
+  });
+
+  it('includes no time series data when all time values are before start time', () => {
+    const cachedQueryInfo = {
+      query: {
+        queryType: QueryType.PropertyValueHistory,
+        refId: 'A'
+      },
+      dataFrame: {
+        name: 'Demo Turbine Asset 1',
+        refId: 'A',
+        fields: [
+          {
+            name: 'time',
+            type: FieldType.time,
+            config: {},
+            values: [
+              1716854399999,
+              1716854400000,  // 2024-05-28T00:00:00Z
+            ],
+          },
+          {
+            name: 'RotationsPerSecond',
+            type: FieldType.number,
+            config: {
+              unit: 'RPS'
+            },
+            values: [
+              1,
+              2,
+            ],
+          },
+        ],
+        length: 2
+      },
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [],
+        },
+      ],
+      length: 0
+    };
+    const dataFrames = trimCachedQueryDataFramesAtStart([cachedQueryInfo], absolutionRange);
+
+    expect(dataFrames).toHaveLength(1);
+    expect(dataFrames).toContainEqual(expectedDataFrame);
+  });
+
+  it('includes no time series data when all time values are after end time', () => {
+    const cachedQueryInfo = {
+      query: {
+        queryType: QueryType.PropertyValueHistory,
+        refId: 'A'
+      },
+      dataFrame: {
+        name: 'Demo Turbine Asset 1',
+        refId: 'A',
+        fields: [
+          {
+            name: 'time',
+            type: FieldType.time,
+            config: {},
+            values: [
+              1716855300001,  // 2024-05-28T00:15:00Z +1ms
+              1716855300002,
+            ],
+          },
+          {
+            name: 'RotationsPerSecond',
+            type: FieldType.number,
+            config: {
+              unit: 'RPS'
+            },
+            values: [
+              1,
+              2,
+            ],
+          },
+        ],
+        length: 2
+      },
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [],
+        },
+      ],
+      length: 0
+    };
+    const dataFrames = trimCachedQueryDataFramesAtStart([cachedQueryInfo], absolutionRange);
+
+    expect(dataFrames).toHaveLength(1);
+    expect(dataFrames).toContainEqual(expectedDataFrame);
+  });
+});

--- a/src/RelativeRangeRequestCache/dataFrameUtils.ts
+++ b/src/RelativeRangeRequestCache/dataFrameUtils.ts
@@ -13,10 +13,8 @@ import { trimTimeSeriesDataFrame, trimTimeSeriesDataFrameReversedTime } from 'da
  * For property value queries, it will return an empty data frame.
  * For all other queries, it will return the trimmed data frame.
  *
- * @param cachedQueryInfos - Cached query infos
- * @param queryType - Query type
- * @param cachedQueryInfos - Cached query infos
- * @param cacheRange - Cache range
+ * @param cachedQueryInfos - Cached query infos to trim
+ * @param cacheRange - Cache range to include
  * @returns Trimmed data frames
  */
 export function trimCachedQueryDataFramesAtStart(cachedQueryInfos: CachedQueryInfo[], cacheRange: AbsoluteTimeRange): DataFrame[] {
@@ -64,10 +62,9 @@ export function trimCachedQueryDataFramesAtStart(cachedQueryInfos: CachedQueryIn
  * For descending ordered data frames, it will return the trimmed data frame.
  * For all other queries, it will return an empty data frame.
  *
- * @param cachedQueryInfos - Cached query infos
- * @param cachedQueryInfos 
- * @param cacheRange 
- * @returns 
+ * @param cachedQueryInfos - Cached query infos to trim
+ * @param cacheRange - Cache range to include
+ * @returns Trimmed data frames
  */
 export function trimCachedQueryDataFramesEnding(cachedQueryInfos: CachedQueryInfo[], cacheRange: AbsoluteTimeRange): DataFrame[] {
   return cachedQueryInfos

--- a/src/RelativeRangeRequestCache/dataFrameUtils.ts
+++ b/src/RelativeRangeRequestCache/dataFrameUtils.ts
@@ -1,0 +1,82 @@
+import { AbsoluteTimeRange, DataFrame } from '@grafana/data';
+import { CachedQueryInfo, TIME_SERIES_QUERY_TYPES } from './types';
+import { QueryType, SiteWiseTimeOrder } from 'types';
+import { trimTimeSeriesDataFrame, trimTimeSeriesDataFrameReversedTime } from 'dataFrameUtils';
+
+/**
+ * Trim cached query data frames based on the query type and time ordering for appending to the start of the data frame.
+ * 
+ * @remarks
+ * This function is used to trim the cached data frames based on the query type and time ordering
+ * to ensure that the data frames are properly formatted for rendering.
+ * For descending ordered data frames, it will return an empty data frame.
+ * For property value queries, it will return an empty data frame.
+ * For all other queries, it will return the trimmed data frame.
+ *
+ * @param cachedQueryInfos - Cached query infos
+ * @param queryType - Query type
+ * @param cachedQueryInfos - Cached query infos
+ * @param cacheRange - Cache range
+ * @returns Trimmed data frames
+ */
+export function trimCachedQueryDataFramesAtStart(cachedQueryInfos: CachedQueryInfo[], cacheRange: AbsoluteTimeRange): DataFrame[] {
+  return cachedQueryInfos
+    .map((cachedQueryInfo) => {
+      const { query: { queryType, timeOrdering }, dataFrame } = cachedQueryInfo;
+      if (timeOrdering === SiteWiseTimeOrder.DESCENDING) {
+        // Descending ordering data frame are added at the end of the request to respect the ordering
+        // See related function - trimCachedQueryDataFramesEnding()
+        return {
+          ...dataFrame,
+          fields: [],
+          length: 0,
+        };
+      }
+
+      // Always refresh PropertyValue
+      if (queryType === QueryType.PropertyValue) {
+        return {
+          ...dataFrame,
+          fields: [],
+          length: 0,
+        };
+      }
+
+      if (TIME_SERIES_QUERY_TYPES.has(queryType)) {
+        return trimTimeSeriesDataFrame({
+          dataFrame: cachedQueryInfo.dataFrame,
+          timeRange: cacheRange,
+          lastObservation: cachedQueryInfo.query.lastObservation,
+        });
+      }
+
+      // No trimming needed
+      return dataFrame;
+    });
+}
+
+/**
+ * Trim cached query data frames based on the time ordering for appending to the end of the data frame.
+ *
+ * @remarks
+ * This function is used to trim the cached data frames based on the time ordering
+ * to ensure that the data frames are properly formatted for rendering.
+ * For descending ordered data frames, it will return the trimmed data frame.
+ * For all other queries, it will return an empty data frame.
+ *
+ * @param cachedQueryInfos - Cached query infos
+ * @param cachedQueryInfos 
+ * @param cacheRange 
+ * @returns 
+ */
+export function trimCachedQueryDataFramesEnding(cachedQueryInfos: CachedQueryInfo[], cacheRange: AbsoluteTimeRange): DataFrame[] {
+  return cachedQueryInfos
+    .filter((cachedQueryInfo) => (cachedQueryInfo.query.timeOrdering === SiteWiseTimeOrder.DESCENDING))
+    .map((cachedQueryInfo) => {
+      return trimTimeSeriesDataFrameReversedTime({
+        dataFrame: cachedQueryInfo.dataFrame,
+        lastObservation: cachedQueryInfo.query.lastObservation,
+        timeRange: cacheRange,
+      });
+    });
+}

--- a/src/RelativeRangeRequestCache/timeRangeUtils.test.ts
+++ b/src/RelativeRangeRequestCache/timeRangeUtils.test.ts
@@ -1,0 +1,93 @@
+import { dateTime } from '@grafana/data';
+import { getRefreshRequestRange, isCacheableTimeRange } from './timeRangeUtils';
+
+describe('isCacheableTimeRange()', () => {
+  it('returns true for TimeRange with relative time from before refresh minutes to now', () => {
+    expect(isCacheableTimeRange({
+      from: dateTime('2024-05-28T00:00:00Z'),
+      to: dateTime('2024-05-28T00:30:00Z'),
+      raw: {
+        from: 'now-30m',
+        to: 'now'
+      ,}
+    })).toBe(true);
+  });
+
+  it('returns false for undefined TimeRange', () => {
+    expect(isCacheableTimeRange(undefined)).toBe(false);
+  });
+
+  it('returns false for TimeRange with absolute time', () => {
+    expect(isCacheableTimeRange({
+      from: dateTime('2024-05-28T00:00:00Z'),
+      to: dateTime('2024-05-28T00:15:00Z'),
+      raw: {
+        from: '2024-05-28T00:00:00Z',
+        to: '2024-05-28T00:15:00Z'
+      ,}
+    })).toBe(false);
+  });
+
+  it('returns false for TimeRange with relative time not greater than refresh minutes', () => {
+    expect(isCacheableTimeRange({
+      from: dateTime('2024-05-28T00:00:00Z'),
+      to: dateTime('2024-05-28T00:15:00Z'),
+      raw: {
+        from: 'now-15m',
+        to: 'now'
+      ,}
+    })).toBe(false);
+  });
+});
+
+describe('getRefreshRequestRange()', () => {
+  it('returns time range with cache ending time as start', () => {
+    const requestRange = {
+      from: dateTime('2024-05-28T00:00:00Z'),
+      to: dateTime('2024-05-28T02:00:00Z'),
+      raw: {
+        from: 'now-2h',
+        to: 'now'
+      ,}
+    };
+
+    const cacheRange = {
+      from: dateTime('2024-05-28T00:00:00Z'),
+      to: dateTime('2024-05-28T01:00:00Z'),
+      raw: {
+        from: 'now-2h',
+        to: 'now'
+      ,}
+    };
+
+    const resultTimeRange = getRefreshRequestRange(requestRange, cacheRange);
+    
+    expect(resultTimeRange.from.isSame(dateTime('2024-05-28T01:00:00Z'))).toBe(true);
+    expect(resultTimeRange.to.isSame(dateTime('2024-05-28T02:00:00Z'))).toBe(true);
+  });
+
+  it('returns time range with refresh minutes when time ranges are the same', () => {
+    const requestRange = {
+      from: dateTime('2024-05-28T00:00:00Z'),
+      to: dateTime('2024-05-28T02:00:00Z'),
+      raw: {
+        from: 'now-2h',
+        to: 'now'
+      ,}
+    };
+
+    const cacheRange = {
+      from: dateTime('2024-05-28T00:00:00Z'),
+      to: dateTime('2024-05-28T02:00:00Z'),
+      raw: {
+        from: 'now-2h',
+        to: 'now'
+      ,}
+    };
+
+    const resultTimeRange = getRefreshRequestRange(requestRange, cacheRange);
+    
+    expect(resultTimeRange.from.isSame(dateTime('2024-05-28T01:45:00Z'))).toBe(true);
+    expect(resultTimeRange.to.isSame(dateTime('2024-05-28T02:00:00Z'))).toBe(true);
+  });
+});

--- a/src/RelativeRangeRequestCache/timeRangeUtils.ts
+++ b/src/RelativeRangeRequestCache/timeRangeUtils.ts
@@ -1,0 +1,49 @@
+import { TimeRange, dateTime } from '@grafana/data';
+import { isRelativeFromNow, minDateTime } from 'timeRangeUtils';
+import { DEFAULT_TIME_SERIES_REFRESH_MINUTES } from './constants';
+
+/**
+ * Check if the given TimeRange is cacheable. A TimeRange is cacheable if it is relative and has data 15 minutes ago.
+ * @param TimeRange to check
+ * @returns true if the TimeRange is cacheable, false otherwise
+ */
+export function isCacheableTimeRange(timeRange?: TimeRange): boolean {
+  if (!timeRange) {
+    return false;
+  }
+
+  const { from, to, raw } = timeRange;
+
+  if (!isRelativeFromNow(raw)) {
+    return false;
+  }
+
+  const defaultRefreshAgo = dateTime(to).subtract(DEFAULT_TIME_SERIES_REFRESH_MINUTES, 'minutes');
+  if (!from.isBefore(defaultRefreshAgo)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Get the refresh TimeRange for a given TimeRange. The refresh TimeRange is the TimeRange that will be used to refresh the cache.
+ *
+ * @remarks
+ * The refresh TimeRange is the TimeRange that will be used to refresh the cache. The TimeRange is usually 15 minutes ago until the end of the request.
+ * Unless the cache data ends earlier than the 15 minutes refresh range, then the TimeRange starts from the end cache data until the end of the request.
+ * 
+ * @param TimeRange to get the refresh TimeRange for
+ * @param TimeRange cacheRange the TimeRange that will be used to refresh the cache
+ * @returns TimeRange the refresh TimeRange
+ */
+export function getRefreshRequestRange(requestRange: TimeRange, cacheRange: TimeRange): TimeRange {
+  const defaultRefreshAgo = dateTime(requestRange.to).subtract(DEFAULT_TIME_SERIES_REFRESH_MINUTES, 'minutes');
+  const from = minDateTime(cacheRange.to, defaultRefreshAgo);
+
+  return {
+    from,
+    to: requestRange.to,
+    raw: requestRange.raw,
+  };
+}

--- a/src/RelativeRangeRequestCache/types.ts
+++ b/src/RelativeRangeRequestCache/types.ts
@@ -1,0 +1,22 @@
+import { DataFrame } from '@grafana/data';
+import { AssetPropertyValueHistoryQuery, ListAssetsQuery, ListAssociatedAssetsQuery, QueryType, SitewiseQuery } from 'types';
+
+export const TIME_SERIES_QUERY_TYPES = new Set<QueryType>([
+  QueryType.PropertyAggregate,
+  QueryType.PropertyInterpolated,
+  QueryType.PropertyValue,
+  QueryType.PropertyValueHistory,
+]);
+
+export interface CachedQueryInfo {
+  query: Pick<SitewiseQueriesUnion, 'queryType' | 'timeOrdering' | 'lastObservation'>;
+  dataFrame: DataFrame;
+}
+
+// Union of all SiteWise queries variants
+export type SitewiseQueriesUnion = SitewiseQuery
+  & Partial<Pick<AssetPropertyValueHistoryQuery, 'timeOrdering'>>
+  & Partial<Pick<ListAssociatedAssetsQuery, 'loadAllChildren'>>
+  & Partial<Pick<ListAssociatedAssetsQuery, 'hierarchyId'>>
+  & Partial<Pick<ListAssetsQuery, 'modelId'>>
+  & Partial<Pick<ListAssetsQuery, 'filter'>>;

--- a/src/SiteWiseQueryPaginator.ts
+++ b/src/SiteWiseQueryPaginator.ts
@@ -1,4 +1,4 @@
-import { DataQueryRequest, DataQueryResponse, DataQueryResponseData, LoadingState } from '@grafana/data';
+import { DataQueryRequest, DataQueryResponse, LoadingState } from '@grafana/data';
 import { appendMatchingFrames } from 'appendFrames';
 import { getNextQueries } from 'getNextQueries';
 import { Subject } from 'rxjs';
@@ -12,6 +12,11 @@ export interface SitewiseQueryPaginatorOptions {
   request: DataQueryRequest<SitewiseQuery>,
   // The function to call to execute the query.
   queryFn: (request: DataQueryRequest<SitewiseQuery>) => Promise<DataQueryResponse>;
+  // The cached response to set as the initial response.
+  cachedResponse?: {
+    start?: DataQueryResponse,
+    end?: DataQueryResponse,
+  },
 }
 
 /**
@@ -34,7 +39,12 @@ export class SitewiseQueryPaginator {
    * @returns An observable that emits the paginated query responses.
    */
   toObservable() {
+    const { request: { requestId }, cachedResponse } = this.options;
     const subject = new Subject<DataQueryResponse>();
+
+    if (cachedResponse?.start) {
+      subject.next({ ...cachedResponse.start, state: LoadingState.Streaming, key: requestId });
+    }
 
     this.paginateQuery(subject);
 
@@ -46,25 +56,26 @@ export class SitewiseQueryPaginator {
    * @param subject The subject to emit the query responses to.
    */
   private async paginateQuery(subject: Subject<DataQueryResponse>) {
-    const { request: initialRequest, queryFn } = this.options;
+    const { request: initialRequest, queryFn, cachedResponse } = this.options;
     const { requestId } = initialRequest;
+    let paginatingRequest = initialRequest;
 
     try {
-      let retrievedData: DataQueryResponseData[] | undefined;
+      let retrievedData = cachedResponse?.start?.data;
       let nextQueries: SitewiseNextQuery[] | undefined;
+      let errorEncountered = false;  // whether there's a error response
       let count = 1;
 
       do {
-        let request = initialRequest;
         if (nextQueries != null) {
-          request = {
-            ...request,
+          paginatingRequest = {
+            ...paginatingRequest,
             requestId: `${requestId}.${++count}`,
             targets: nextQueries,
           };
         }
 
-        const response = await queryFn(request);
+        const response = await queryFn(paginatingRequest);
         if (retrievedData == null) {
           retrievedData = response.data;
         } else {
@@ -76,11 +87,16 @@ export class SitewiseQueryPaginator {
           break;
         }
 
-        nextQueries = getNextQueries(request, response);
-        const loadingState = nextQueries ? LoadingState.Streaming : LoadingState.Done;
+        nextQueries = getNextQueries(paginatingRequest, response);
+        const loadingState = nextQueries || cachedResponse?.end != null ? LoadingState.Streaming : LoadingState.Done;
 
         subject.next({ ...response, data: retrievedData, state: loadingState, key: requestId });
       } while (nextQueries != null && !subject.closed);
+
+      if (cachedResponse?.end != null && !errorEncountered) {
+        retrievedData = appendMatchingFrames(retrievedData, cachedResponse.end.data);
+        subject.next({ ...cachedResponse.end, data: retrievedData , state: LoadingState.Done, key: requestId });
+      }
 
       subject.complete();
     } catch (err) {

--- a/src/SiteWiseQueryPaginator.ts
+++ b/src/SiteWiseQueryPaginator.ts
@@ -63,7 +63,7 @@ export class SitewiseQueryPaginator {
     try {
       let retrievedData = cachedResponse?.start?.data;
       let nextQueries: SitewiseNextQuery[] | undefined;
-      let errorEncountered = false;  // whether there's a error response
+      const errorEncountered = false;  // whether there's a error response
       let count = 1;
 
       do {

--- a/src/components/browser/AssetBrowser.tsx
+++ b/src/components/browser/AssetBrowser.tsx
@@ -40,7 +40,7 @@ export class AssetBrowser extends Component<Props, State> {
   }
 
   async componentDidUpdate(oldProps: Props) {
-    let update: State = { ...this.state };
+    const update: State = { ...this.state };
     let shouldUpdate = false;
 
     if (this.props.region !== oldProps.region) {

--- a/src/components/query/ClientCacheRow.tsx
+++ b/src/components/query/ClientCacheRow.tsx
@@ -16,7 +16,7 @@ export const ClientCacheRow = ({clientCache, newFormStylingEnabled, onClientCach
           <EditorField
             label="Client cache"
             htmlFor="clientCache"
-            tooltip="Enable to cache results from the query in. This will improve performance for repeated queries with relative time range."
+            tooltip="Enable to cache results in the browser that are older than 15 minutes. This will improve performance for repeated queries with relative time range."
           >
             <Switch id="clientCache" value={clientCache} onChange={onClientCacheChange} />
           </EditorField>

--- a/src/components/query/ClientCacheRow.tsx
+++ b/src/components/query/ClientCacheRow.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { InlineField, InlineSwitch, Switch } from '@grafana/ui';
+import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
+
+interface Props {
+  clientCache?: boolean;
+  newFormStylingEnabled?: boolean;
+  onClientCacheChange: (evt: React.SyntheticEvent<HTMLInputElement>) => void;
+}
+
+export const ClientCacheRow = ({clientCache, newFormStylingEnabled, onClientCacheChange}: Props) => {
+  if (newFormStylingEnabled) {
+    return (
+      <EditorRow>
+        <EditorFieldGroup>
+          <EditorField
+            label="Client cache"
+            htmlFor="clientCache"
+            tooltip="Enable to cache results from the query in. This will improve performance for repeated queries with relative time range."
+          >
+            <Switch id="clientCache" value={clientCache} onChange={onClientCacheChange} />
+          </EditorField>
+        </EditorFieldGroup>
+      </EditorRow>
+    );
+  }
+
+  return (
+    <div className="gf-form">
+      <InlineField
+          label="Client cache"
+          htmlFor="clientCache"
+          tooltip="Enable to cache results from the query. This will improve performance for repeated queries with relative time range."
+      >
+        <InlineSwitch value={clientCache} onChange={onClientCacheChange} />
+      </InlineField>
+    </div>
+  );
+};

--- a/src/components/query/QueryEditor.test.tsx
+++ b/src/components/query/QueryEditor.test.tsx
@@ -144,6 +144,7 @@ describe('QueryEditor', () => {
         expect(screen.getByText('Quality')).toBeInTheDocument();
         expect(screen.getByText('Expand Time Range')).toBeInTheDocument();
         expect(screen.getByText('Format L4E Anomaly Result')).toBeInTheDocument();
+        expect(screen.getByText('Client cache')).toBeInTheDocument();
         expect(screen.getByText('Time')).toBeInTheDocument();
         expect(screen.getByText('Format')).toBeInTheDocument();
       });
@@ -173,6 +174,7 @@ describe('QueryEditor', () => {
         expect(screen.getByText('Property')).toBeInTheDocument();
         expect(screen.getByText('Quality')).toBeInTheDocument();
         expect(screen.getByText('Format L4E Anomaly Result')).toBeInTheDocument();
+        expect(screen.getByText('Client cache')).toBeInTheDocument();
         expect(screen.getByText('Time')).toBeInTheDocument();
         expect(screen.getByText('Format')).toBeInTheDocument();
       });

--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -11,12 +11,14 @@ import { PropertyQueryEditor } from './PropertyQueryEditor';
 import { EditorField, EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
+import { ClientCacheRow } from './ClientCacheRow';
 
 type Props = QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions>;
 
 const queryDefaults: Partial<SitewiseQuery> = {
   maxPageAggregations: 1,
   flattenL4e: true,
+  clientCache: true,
 };
 
 export const firstLabelWith = 20;
@@ -44,6 +46,11 @@ export function QueryEditor(props: Props) {
   const onRegionChange = (sel: SelectableValue<string>) => {
     const { onChange, query } = props;
     onChange({ ...query, assetId: undefined, propertyId: undefined, region: sel.value });
+  };
+
+  const onClientCacheChange = (evt: React.SyntheticEvent<HTMLInputElement>) => {
+    const { onChange, query } = props;
+    onChange({ ...query, clientCache: evt.currentTarget.checked });
   };
 
   const renderQuery = (query: SitewiseQuery, newFormStylingEnabled?: boolean) => {
@@ -79,6 +86,8 @@ export function QueryEditor(props: Props) {
       </LinkButton>
     </div>
   ) : undefined;
+
+  const clientCacheRow = <ClientCacheRow clientCache={query.clientCache} newFormStylingEnabled={newFormStylingEnabled} onClientCacheChange={onClientCacheChange}></ClientCacheRow>;
 
   return (
     <>
@@ -119,6 +128,7 @@ export function QueryEditor(props: Props) {
               </EditorFieldGroup>
             </EditorRow>
             {renderQuery(query, true)}
+            {clientCacheRow}
           </EditorRows>
         </>
       ) : (
@@ -163,6 +173,8 @@ export function QueryEditor(props: Props) {
           </div>
 
           {renderQuery(query)}
+          {clientCacheRow}
+          <ClientCacheRow clientCache={query.clientCache} newFormStylingEnabled={newFormStylingEnabled} onClientCacheChange={onClientCacheChange}></ClientCacheRow>
         </>
       )}
     </>

--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -174,7 +174,6 @@ export function QueryEditor(props: Props) {
 
           {renderQuery(query)}
           {clientCacheRow}
-          <ClientCacheRow clientCache={query.clientCache} newFormStylingEnabled={newFormStylingEnabled} onClientCacheChange={onClientCacheChange}></ClientCacheRow>
         </>
       )}
     </>

--- a/src/dataFrameUtils.test.ts
+++ b/src/dataFrameUtils.test.ts
@@ -1,0 +1,340 @@
+import { DataFrame, FieldType, dateTime } from '@grafana/data';
+import { trimTimeSeriesDataFrame, trimTimeSeriesDataFrameReversedTime } from './dataFrameUtils'
+
+describe('trimTimeSeriesDataFrame()', () => {
+  const timeRange = {
+    from: dateTime('2024-05-28T00:00:00Z').valueOf(),
+    to: dateTime('2024-05-28T00:15:00Z').valueOf(),
+  };
+
+  const dataFrame: DataFrame = {
+    name: 'Demo Turbine Asset 1',
+    refId: 'A',
+    fields: [
+      {
+        name: 'time',
+        type: FieldType.time,
+        config: {},
+        values: [
+          1716854400000,  // 2024-05-28T00:00:00Z
+          1716854400001,  // 2024-05-28T00:15:00Z + 1ms
+          1716855300000,  // 2024-05-28T00:15:00Z
+          1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+        ],
+      },
+      {
+        name: 'RotationsPerSecond',
+        type: FieldType.number,
+        config: {
+          unit: 'RPS'
+        },
+        values: [
+          1,
+          2,
+          3,
+          4,
+        ],
+      },
+    ],
+    length: 4
+  };
+
+  const dataFrameDiff: DataFrame = {
+    name: 'Demo Turbine Asset 1',
+    refId: 'A',
+    fields: [
+      {
+        name: 'time',
+        type: FieldType.time,
+        config: {},
+        values: [
+          1716854400001,  // 2024-05-28T00:15:00Z + 1ms
+        ],
+      },
+      {
+        name: 'RotationsPerSecond',
+        type: FieldType.number,
+        config: {
+          unit: 'RPS'
+        },
+        values: [
+          2,
+        ],
+      },
+    ],
+    length: 4
+  };
+
+  it('trims time series data frame', () => {
+    const trimParams = {
+      dataFrame,
+      timeRange,
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [
+            1716854400001,  // +1ms
+            1716855300000,  // 2024-05-28T00:15:00Z
+          ],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [
+            2,
+            3,
+          ],
+        },
+      ],
+      length: 2
+    };
+    const dataFrameResult = trimTimeSeriesDataFrame(trimParams);
+
+    expect(dataFrameResult).toEqual(expectedDataFrame);
+  });
+
+  it('trims time series data frame with last observations', () => {
+    const trimParams = {
+      dataFrame,
+      lastObservation: true,
+      timeRange,
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [
+            1716854400000,  // 2024-05-28T00:00:00Z
+            1716854400001,  // +1ms
+            1716855300000,  // 2024-05-28T00:15:00Z
+          ],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [
+            1,
+            2,
+            3,
+          ],
+        },
+      ],
+      length: 3
+    };
+    const dataFrameResult = trimTimeSeriesDataFrame(trimParams);
+
+    expect(dataFrameResult).toEqual(expectedDataFrame);
+  });
+
+  it('trims diff time series data frame', () => {
+    const trimParams = {
+      dataFrame: dataFrameDiff,
+      timeRange,
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [
+            1716854400001,  // +1ms
+          ],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [
+            2,
+          ],
+        },
+      ],
+      length: 1
+    };
+    const dataFrameResult = trimTimeSeriesDataFrame(trimParams);
+
+    expect(dataFrameResult).toEqual(expectedDataFrame);
+  });
+});
+
+describe('trimTimeSeriesDataFrameReversed()', () => {
+  const timeRange = {
+    from: dateTime('2024-05-28T00:00:00Z').valueOf(),
+    to: dateTime('2024-05-28T00:15:00Z').valueOf(),
+  };
+
+  const dataFrameDescending: DataFrame = {
+    name: 'Demo Turbine Asset 1',
+    refId: 'A',
+    fields: [
+      {
+        name: 'time',
+        type: FieldType.time,
+        config: {},
+        values: [
+          1716855300001,  // 2024-05-28T00:15:00Z + 1ms
+          1716855300000,  // 2024-05-28T00:15:00Z
+          1716854400001,  // 2024-05-28T00:00:00Z + 1ms
+          1716854400000,  // 2024-05-28T00:00:00Z
+        ],
+      },
+      {
+        name: 'RotationsPerSecond',
+        type: FieldType.number,
+        config: {
+          unit: 'RPS'
+        },
+        values: [4,3,2,1],
+      },
+    ],
+    length: 4
+  };
+
+  const dataFrameDescendingDiff: DataFrame = {
+    name: 'Demo Turbine Asset 1',
+    refId: 'A',
+    fields: [
+      {
+        name: 'time',
+        type: FieldType.time,
+        config: {},
+        values: [
+          1716854400001,  // 2024-05-28T00:00:00Z + 1ms
+        ],
+      },
+      {
+        name: 'RotationsPerSecond',
+        type: FieldType.number,
+        config: {
+          unit: 'RPS'
+        },
+        values: [2],
+      },
+    ],
+    length: 4
+  };
+  
+  it('trims descending time series data frame', () => {
+    const trimParams = {
+      dataFrame: dataFrameDescending,
+      timeRange,
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [
+            1716855300000,  // 2024-05-28T00:15:00Z
+            1716854400001,  // 2024-05-28T00:00:00Z+1ms
+          ],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [3,2],
+        },
+      ],
+      length: 2
+    };
+    const dataFrame = trimTimeSeriesDataFrameReversedTime(trimParams);
+
+    expect(dataFrame).toEqual(expectedDataFrame);
+  });
+  
+  it('trims descending time series data with last observations of time-series type - "%s"', () => {
+    const trimParams = {
+      dataFrame: dataFrameDescending,
+      lastObservation: true,
+      timeRange,
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [
+            1716855300000,  // 2024-05-28T00:15:00Z
+            1716854400001,  // 2024-05-28T00:00:00Z+1ms
+            1716854400000,  // 2024-05-28T00:00:00Z
+          ],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [3,2,1],
+        },
+      ],
+      length: 3
+    };
+    const dataFrame = trimTimeSeriesDataFrameReversedTime(trimParams);
+
+    expect(dataFrame).toEqual(expectedDataFrame);
+  });
+
+  it('trims diff descending time series data frame', () => {
+    const trimParams = {
+      dataFrame: dataFrameDescendingDiff,
+      timeRange,
+    };
+    const expectedDataFrame: DataFrame = {
+      name: 'Demo Turbine Asset 1',
+      refId: 'A',
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [
+            1716854400001,  // 2024-05-28T00:00:00Z+1ms
+          ],
+        },
+        {
+          name: 'RotationsPerSecond',
+          type: FieldType.number,
+          config: {
+            unit: 'RPS'
+          },
+          values: [2],
+        },
+      ],
+      length: 1
+    };
+    const dataFrame = trimTimeSeriesDataFrameReversedTime(trimParams);
+
+    expect(dataFrame).toEqual(expectedDataFrame);
+  });
+});

--- a/src/dataFrameUtils.ts
+++ b/src/dataFrameUtils.ts
@@ -8,10 +8,10 @@ interface TrimParams {
 
 /**
  * Trim the time series data frame to the specified time range.
- * @param param0 - The parameters for trimming the data frame.
- * @param param0.dataFrame - The data frame to trim.
- * @param param0.timeRange - The time range to trim to.
- * @param param0.lastObservation - Whether to include the last observation in the range.
+ * @param trimParams - The parameters for trimming the data frame.
+ * @param trimParams.dataFrame - The data frame to trim.
+ * @param trimParams.timeRange - The time range to trim to.
+ * @param trimParams.lastObservation - Whether to include the last observation in the range.
  * @returns The trimmed data frame.
  */
 export function trimTimeSeriesDataFrame({
@@ -34,7 +34,7 @@ export function trimTimeSeriesDataFrame({
     return dataFrame;
   }
 
-  let timeValues = timeField.values.toArray();
+  const timeValues = timeField.values.toArray();
 
   let fromIndex = timeValues.findIndex(time => time > from);  // from is exclusive
   if (fromIndex === -1) {
@@ -65,10 +65,10 @@ export function trimTimeSeriesDataFrame({
 
 /**
  * Trim the time series data frame to the specified time range where the time field is in reversed order.
- * @param param0 - The parameters for trimming the data frame.
- * @param param0.dataFrame - The data frame to trim.
- * @param param0.timeRange - The time range to trim to.
- * @param param0.lastObservation - Whether to include the last observation in the range.
+ * @param trimParams - The parameters for trimming the data frame.
+ * @param trimParams.dataFrame - The data frame to trim.
+ * @param trimParams.timeRange - The time range to trim to.
+ * @param trimParams.lastObservation - Whether to include the last observation in the range.
  * @returns The trimmed data frame.
  */
 export function trimTimeSeriesDataFrameReversedTime({
@@ -92,7 +92,7 @@ export function trimTimeSeriesDataFrameReversedTime({
   }
 
   // Copy before reverse in place
-  let timeValues = [...timeField.values.toArray()].reverse();
+  const timeValues = [...timeField.values.toArray()].reverse();
   
   let fromIndex = timeValues.findIndex(time => time > from);  // from is exclusive
   if (fromIndex === -1) {

--- a/src/dataFrameUtils.ts
+++ b/src/dataFrameUtils.ts
@@ -1,0 +1,126 @@
+import { AbsoluteTimeRange, ArrayVector, DataFrame, FieldType } from '@grafana/data';
+
+interface TrimParams {
+  dataFrame: DataFrame;
+  timeRange: AbsoluteTimeRange;
+  lastObservation?: boolean;
+};
+
+/**
+ * Trim the time series data frame to the specified time range.
+ * @param param0 - The parameters for trimming the data frame.
+ * @param param0.dataFrame - The data frame to trim.
+ * @param param0.timeRange - The time range to trim to.
+ * @param param0.lastObservation - Whether to include the last observation in the range.
+ * @returns The trimmed data frame.
+ */
+export function trimTimeSeriesDataFrame({
+  dataFrame,
+  timeRange: { from, to },
+  lastObservation,
+}: TrimParams): DataFrame {
+  const { fields } = dataFrame;
+  if (fields == null || fields.length === 0) {
+    return {
+      ...dataFrame,
+      fields: [],
+      length: 0,
+    }
+  }
+
+  const timeField = fields.find(field => field.name === 'time' && field.type === FieldType.time);
+  if (timeField == null) {
+    // return the original data frame if a time field cannot be found
+    return dataFrame;
+  }
+
+  let timeValues = timeField.values.toArray();
+
+  let fromIndex = timeValues.findIndex(time => time > from);  // from is exclusive
+  if (fromIndex === -1) {
+    // no time value within range; include no data in the slice
+    fromIndex = timeValues.length ;
+  } else if (lastObservation) {
+    // Keeps 1 extra data point before the range
+    fromIndex = Math.max(fromIndex - 1, 0);
+  }
+
+  let toIndex = timeValues.findIndex(time => time > to);  // to is inclusive
+  if (toIndex === -1) {
+    // all time values before `to`
+    toIndex = timeValues.length;
+  }
+
+  const trimmedFields = fields.map(field => ({
+    ...field,
+    values: new ArrayVector(field.values.toArray().slice(fromIndex, toIndex)),
+  }));
+  
+  return {
+    ...dataFrame,
+    fields: trimmedFields,
+    length: trimmedFields[0].values.length,
+  };
+}
+
+/**
+ * Trim the time series data frame to the specified time range where the time field is in reversed order.
+ * @param param0 - The parameters for trimming the data frame.
+ * @param param0.dataFrame - The data frame to trim.
+ * @param param0.timeRange - The time range to trim to.
+ * @param param0.lastObservation - Whether to include the last observation in the range.
+ * @returns The trimmed data frame.
+ */
+export function trimTimeSeriesDataFrameReversedTime({
+  dataFrame,
+  timeRange: { from, to },
+  lastObservation,
+}: TrimParams): DataFrame {
+  const { fields } = dataFrame;
+  if (fields == null || fields.length === 0) {
+    return {
+      ...dataFrame,
+      fields: [],
+      length: 0,
+    }
+  }
+
+  const timeField = fields.find(field => field.name === 'time' && field.type === FieldType.time);
+  if (timeField == null) {
+    // return the original data frame if a time field cannot be found
+    return dataFrame;
+  }
+
+  // Copy before reverse in place
+  let timeValues = [...timeField.values.toArray()].reverse();
+  
+  let fromIndex = timeValues.findIndex(time => time > from);  // from is exclusive
+  if (fromIndex === -1) {
+    // no time value within range; include no data in the slice
+    fromIndex = timeValues.length ;
+  } else if (lastObservation) {
+    // Keeps 1 extra data point before the range
+    fromIndex = Math.max(fromIndex - 1, 0);
+  }
+
+  let toIndex = timeValues.findIndex(time => time > to);  // to is inclusive
+  if (toIndex === -1) {
+    // all time values before `to`
+    toIndex = timeValues.length;
+  }
+
+  const trimmedFields = fields.map(field => {
+    const dataValues = [...field.values.toArray()].reverse().slice(fromIndex, toIndex);
+
+    return {
+      ...field,
+      values: new ArrayVector(dataValues.reverse()),
+    };
+  });
+  
+  return {
+    ...dataFrame,
+    fields: trimmedFields,
+    length: trimmedFields[0].values.length,
+  };
+}

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -261,7 +261,7 @@ export function frameToAssetInfo(res: DescribeAssetResult): AssetInfo {
 }
 
 export function assetSummaryToAssetInfo(res: DataFrameView<AssetSummary>): AssetInfo[] {
-  let results: AssetInfo[] = [];
+  const results: AssetInfo[] = [];
 
   for (const info of res.toArray()) {
     const hierarchy: AssetPropertyInfo[] = JSON.parse(info.hierarchies); // has Id, Name

--- a/src/timeRangeUtils.test.ts
+++ b/src/timeRangeUtils.test.ts
@@ -1,0 +1,102 @@
+import { dateTime } from '@grafana/data';
+import { isRelativeFromNow, isTimeRangeCoveringStart, minDateTime } from 'timeRangeUtils';
+
+describe('isTimeRangeCoveringStart()', () => {
+  it('returns true when subject and object both starting at the same time.', () => {
+    const range = {
+      from: dateTime('2024-05-28T20:59:49.659Z'),
+      to: dateTime('2024-05-28T21:29:49.659Z'),
+      raw: { from: 'now-1h', to: 'now' },
+    };
+    const actual = isTimeRangeCoveringStart(range, range);
+
+    expect(actual).toBe(true);
+  });
+
+  it('returns true when object is before subject and overlaps the subject start time', () => {
+    const objectRange = {
+      from: dateTime('2024-05-28T20:00:00Z'),
+      to: dateTime('2024-05-28T22:00:00Z'),
+      raw: { from: 'now-1h', to: 'now' },
+    };
+    const subjectRange = {
+      from: dateTime('2024-05-28T21:00:00Z'),
+      to: dateTime('2024-05-28T25:00:00Z'),
+      raw: { from: 'now-1h', to: 'now' },
+    };
+    const actual = isTimeRangeCoveringStart(objectRange, subjectRange);
+
+    expect(actual).toBe(true);
+  });
+
+  it('returns false when object is before subject but ends before the subject start time', () => {
+    const objectRange = {
+      from: dateTime('2024-05-28T20:00:00Z'),
+      to: dateTime('2024-05-28T21:00:00Z'),
+      raw: { from: 'now-1h', to: 'now' },
+    };
+    const subjectRange = {
+      from: dateTime('2024-05-28T22:00:00Z'),
+      to: dateTime('2024-05-28T25:00:00Z'),
+      raw: { from: 'now-1h', to: 'now' },
+    };
+    const actual = isTimeRangeCoveringStart(objectRange, subjectRange);
+
+    expect(actual).toBe(false);
+  });
+
+  it('returns false when object is before subject but ends at subject start time', () => {
+    const objectRange = {
+      from: dateTime('2024-05-28T20:00:00Z'),
+      to: dateTime('2024-05-28T22:00:00Z'),
+      raw: { from: 'now-1h', to: 'now' },
+    };
+    const subjectRange = {
+      from: dateTime('2024-05-28T22:00:00Z'),
+      to: dateTime('2024-05-28T25:00:00Z'),
+      raw: { from: 'now-1h', to: 'now' },
+    };
+    const actual = isTimeRangeCoveringStart(objectRange, subjectRange);
+
+    expect(actual).toBe(false);
+  });
+});
+
+describe('minDateTime()', () => {
+  it('returns the minimum DateTime', () => {
+    expect(minDateTime(
+      dateTime(0),
+      dateTime(1),
+      dateTime(2),
+    )).toEqual(dateTime(0));
+  });
+});
+
+describe('isRelativeFromNow()', () => {
+  it('returns true for TimeRange with relative times to now', () => {
+    expect(isRelativeFromNow({
+      from: 'now-1h', to: 'now',
+    })).toBe(true);
+  });
+
+  it('returns false for TimeRange with absolute times', () => {
+    expect(isRelativeFromNow({
+      from: '2024-05-28T00:00:00Z',
+      to: '2024-05-28T01:00:00Z',
+    })).toBe(false);
+  });
+
+  it('returns false for TimeRange with absolute from time', () => {
+    expect(isRelativeFromNow({
+      from: '2024-05-28T00:00:00Z',
+      to: 'now',
+    })).toBe(false);
+  });
+
+  it('returns false for TimeRange with absolute to time', () => {
+    expect(isRelativeFromNow({
+      from: 'now-1',
+      to: '2024-05-28T00:00:00Z',
+    })).toBe(false);
+  });
+});

--- a/src/timeRangeUtils.ts
+++ b/src/timeRangeUtils.ts
@@ -1,0 +1,56 @@
+import { DateTime, RawTimeRange, TimeRange, dateTime } from '@grafana/data';
+
+/**
+ * Checks if the subject TimeRange covers the start time of the object TimeRange.
+ *
+ * @param subjectRange - The TimeRange to check if it covers the start time of the object.
+ * @param objectRange - The TimeRange to check if its start time is covered by the subject.
+ * @returns True if the subject TimeRange covers the start time of the object, false otherwise.
+ */
+export function isTimeRangeCoveringStart(subjectRange: TimeRange, objectRange: TimeRange): boolean {
+  const { from: subjectFrom, to: subjectTo } = subjectRange;
+  const { from: objectFrom } = objectRange;
+
+  /*
+   * True if both time ranges start at the same time.
+   *
+   * Positive example (same from time):
+   *   subject: <from>...
+   *   object:  <from>...
+   */
+  if (objectFrom.isSame(subjectFrom)) {
+    return true;
+  }
+
+  /*
+   * True if subject starts before object starts and overlaps the object start time
+   *
+   * Positive example (subject from and to wrap around object from):
+   *   subject: <from>......<to>
+   *   object:  ......<from>....(disregard to)
+   *
+   * Negative example (subject from and to both before object):
+   *   subject: <from>.<to>.......
+   *   object:  ...........<from>.(disregard to)
+   */
+  if (subjectFrom.isBefore(objectFrom) && objectFrom.isBefore(subjectTo)) {
+    return true;
+  }
+
+  return false;
+}
+
+export function minDateTime(firstDateTimes: DateTime, ...dateTimes: DateTime[]) {
+  const minValue = Math.min(firstDateTimes.valueOf(), ...dateTimes.map((dateTime) => dateTime.valueOf()));
+  return dateTime(minValue);
+}
+
+export function isRelativeFromNow(timeRange: RawTimeRange): boolean {
+  const { from, to } = timeRange;
+
+  if (typeof from !== 'string' || typeof to !== 'string') {
+    return false;
+  }
+
+  return from.startsWith('now-') && to === 'now';
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface SitewiseQuery extends DataQuery {
   lastObservation?: boolean;
   flattenL4e?: boolean;
   maxPageAggregations?: number;
+  clientCache?: boolean;
 }
 
 export interface SitewiseNextQuery extends SitewiseQuery {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -18,7 +18,7 @@ export class SitewiseVariableSupport extends CustomVariableSupport<DataSource, S
 
   query(request: DataQueryRequest<SitewiseQuery>): Observable<DataQueryResponse> {
     assign(request.targets, [{ ...request.targets[0], refId: 'A' }]);
-    let response = this.datasource.query(request);
+    const response = this.datasource.query(request);
     switch (request.targets[0].queryType) {
       case QueryType.ListAssetModels:
       case QueryType.ListAssets:
@@ -39,7 +39,7 @@ export class SitewiseVariableSupport extends CustomVariableSupport<DataSource, S
         return {data: new DataFrameView<AssetModelSummary>(data)};
       }),
       map((res) => {
-        let newData = res.data.map((m)=>{
+        const newData = res.data.map((m)=>{
           return {
           value: m.id,
           text: m.name,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

Loading a huge amount of data takes a lot of time and also, if the dashboard is set to auto refresh then most of the times the dashboard refreshes while the data is still getting loaded. This is not a good user experience and makes the dashboard unusable.

This PR added a cache to the `DataSource.ts` on the frontend. The cache `RelativeRangeCache.ts` tracks a history of the relative range requests and their data frame responses. This cache allows the DataSource to reuse the cached data frame responses and refreshes only the most recent data, reducing the request time range; hence, bringing a snappy refresh experience for customers.

**After this PR:**
- the request time was 0.3 s compares to 1.5 s before (the effect is greater for greater range)
- the last 15 minutes of data are refreshed 15:15 (from) - 15:30 (now)

https://github.com/grafana/iot-sitewise-datasource/assets/50635800/9998ad8e-2296-47da-8e59-6085247e705d

**Before this PR:**

https://github.com/grafana/iot-sitewise-datasource/assets/50635800/35c8adb5-95a7-4f6d-b9a0-15f68f7ed4d6





**Which issue(s) this PR fixes**: N/A

Fixes https://github.com/grafana/iot-sitewise-datasource/issues/321

**Special notes for your reviewer**:
- the last 15 minutes of data are always refreshed to ensure late data are retrieved
- the "Get Property Value" query is always refreshed to ensure there it is always the latest value
- similar PR done in the past https://github.com/grafana/iot-sitewise-datasource/pull/262