### PR TITLE
Adding a lint rule to prefer const over let

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "./.config/.eslintrc"
+  "extends": "./.config/.eslintrc",
+  "rules": {
+    "prefer-const": "warn"
+  }
 }


### PR DESCRIPTION
Came up while reviewing https://github.com/grafana/iot-sitewise-datasource/pull/318

Not sure why this isn't on by default tbh, but seems like a good start to just add it to the individual plugin for now