### PR TITLE
fix: removed unsupported time ordering from interpolated query; cache…

### DIFF
--- a/src/RelativeRangeRequestCache/RelativeRangeCache.ts
+++ b/src/RelativeRangeRequestCache/RelativeRangeCache.ts
@@ -2,7 +2,7 @@ import { DataFrame, DataQueryRequest, DataQueryResponse, LoadingState, TimeRange
 import { isTimeRangeCoveringStart } from 'timeRangeUtils';
 import { SitewiseQuery } from 'types';
 import { RequestCacheId, generateSiteWiseRequestCacheId } from './cacheIdUtils';
-import { CachedQueryInfo, TIME_SERIES_QUERY_TYPES } from './types';
+import { CachedQueryInfo, isTimeSeriesQueryType } from './types';
 import { trimCachedQueryDataFramesAtStart, trimCachedQueryDataFramesEnding } from './dataFrameUtils';
 import { getRefreshRequestRange, isCacheableTimeRange } from './timeRangeUtils';
 
@@ -174,7 +174,7 @@ export class RelativeRangeCache {
     return {
       ...request,
       range,
-      targets: targets.filter(({ queryType }) => TIME_SERIES_QUERY_TYPES.has(queryType)),
+      targets: targets.filter(({ queryType }) => isTimeSeriesQueryType(queryType)),
     };
   }
 }

--- a/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
@@ -1,4 +1,4 @@
-import { QueryType, SiteWiseQuality, SiteWiseResolution, SiteWiseResponseFormat, SiteWiseTimeOrder } from 'types';
+import { AggregateType, QueryType, SiteWiseQuality, SiteWiseResolution, SiteWiseResponseFormat, SiteWiseTimeOrder } from 'types';
 import { generateSiteWiseQueriesCacheId, generateSiteWiseRequestCacheId } from './cacheIdUtils';
 import { dateTime } from '@grafana/data';
 import { SitewiseQueriesUnion } from './types';
@@ -27,6 +27,7 @@ function createSiteWiseQuery(id: number): SitewiseQueriesUnion {
     hierarchyId: `mock-hierarchy-${id}`,
     modelId: `mock-model-${id}`,
     filter: 'ALL',
+    aggregates: [AggregateType.AVERAGE],
   };
 }
 
@@ -34,8 +35,8 @@ describe('generateSiteWiseQueriesCacheId()', () => {
   it('parses SiteWise Queries into cache Id', () => {
     const actualId = generateSiteWiseQueriesCacheId([createSiteWiseQuery(1), createSiteWiseQuery(2)]);
     const expectedId = JSON.stringify([
-      '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL"]',
-      '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL"]'
+      '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"]]',
+      '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"]]'
     ]);
 
     expect(actualId).toEqual(expectedId);
@@ -82,7 +83,7 @@ describe('generateSiteWiseQueriesCacheId()', () => {
     };
     const actualId = generateSiteWiseQueriesCacheId([query]);
     const expectedId = JSON.stringify([
-      '["ListAssets",null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]',
+      '["ListAssets",null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]',
     ]);
 
     expect(actualId).toEqual(expectedId);
@@ -112,8 +113,8 @@ describe('generateSiteWiseRequestCacheId()', () => {
     const expectedId = JSON.stringify([
       'now-15m',
       JSON.stringify([
-        '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL"]',
-        '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL"]'
+        '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"]]',
+        '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"]]'
       ])
     ]);
 

--- a/src/RelativeRangeRequestCache/cacheIdUtils.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.ts
@@ -40,6 +40,7 @@ function generateSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId
     hierarchyId,
     modelId,
     filter,
+    aggregates,
   } = query;
 
   /*
@@ -66,5 +67,6 @@ function generateSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId
     hierarchyId,
     modelId,
     filter,
+    aggregates,
   ]);
 }

--- a/src/RelativeRangeRequestCache/dataFrameUtils.test.ts
+++ b/src/RelativeRangeRequestCache/dataFrameUtils.test.ts
@@ -153,7 +153,6 @@ describe('trimCachedQueryDataFrames', () => {
 
   it.each([
     QueryType.PropertyAggregate,
-    QueryType.PropertyInterpolated,
     QueryType.PropertyValueHistory,
   ])('trims descending time series data of time-series type - "%s"', (queryType: QueryType) => {
     const cachedQueryInfo = {

--- a/src/RelativeRangeRequestCache/types.ts
+++ b/src/RelativeRangeRequestCache/types.ts
@@ -1,20 +1,34 @@
 import { DataFrame } from '@grafana/data';
-import { AssetPropertyValueHistoryQuery, ListAssetsQuery, ListAssociatedAssetsQuery, QueryType, SitewiseQuery } from 'types';
+import { AssetPropertyAggregatesQuery, AssetPropertyValueHistoryQuery, ListAssetsQuery, ListAssociatedAssetsQuery, QueryType, SitewiseQuery } from 'types';
 
-export const TIME_SERIES_QUERY_TYPES = new Set<QueryType>([
+const TIME_SERIES_QUERY_TYPES = new Set<QueryType>([
   QueryType.PropertyAggregate,
   QueryType.PropertyInterpolated,
   QueryType.PropertyValue,
   QueryType.PropertyValueHistory,
 ]);
 
+export function isTimeSeriesQueryType(queryType: QueryType) {
+  return TIME_SERIES_QUERY_TYPES.has(queryType);
+}
+
+const TIME_ORDERING_QUERY_TYPES = new Set<QueryType>([
+  QueryType.PropertyAggregate,
+  QueryType.PropertyValueHistory,
+]);
+
+export function isTimeOrderingQueryType(queryType: QueryType) {
+  return TIME_ORDERING_QUERY_TYPES.has(queryType);
+}
+
 export interface CachedQueryInfo {
-  query: Pick<SitewiseQueriesUnion, 'queryType' | 'timeOrdering' | 'lastObservation'>;
+  query: SitewiseQueriesUnion;
   dataFrame: DataFrame;
 }
 
 // Union of all SiteWise queries variants
 export type SitewiseQueriesUnion = SitewiseQuery
+  & Partial<Pick<AssetPropertyAggregatesQuery, 'aggregates'>>
   & Partial<Pick<AssetPropertyValueHistoryQuery, 'timeOrdering'>>
   & Partial<Pick<ListAssociatedAssetsQuery, 'loadAllChildren'>>
   & Partial<Pick<ListAssociatedAssetsQuery, 'hierarchyId'>>

--- a/src/components/query/QualityAndOrderRow.tsx
+++ b/src/components/query/QualityAndOrderRow.tsx
@@ -9,6 +9,7 @@ import {
   SiteWiseResolution,
   isAssetPropertyInterpolatedQuery,
   SiteWiseResponseFormat,
+  QueryType,
 } from 'types';
 import { InlineField, Select } from '@grafana/ui';
 import { SitewiseQueryEditorProps } from './types';
@@ -62,11 +63,6 @@ export class QualityAndOrderRow extends PureComponent<Props> {
     onChange({ ...query, quality: sel.value });
   };
 
-  onOrderChange = (sel: SelectableValue<SiteWiseTimeOrder>) => {
-    const { onChange, query } = this.props;
-    onChange({ ...query, timeOrdering: sel.value });
-  };
-
   onResponseFormatChange = (sel: SelectableValue<SiteWiseResponseFormat>) => {
     const { onChange, query } = this.props;
     onChange({ ...query, responseFormat: sel.value });
@@ -81,6 +77,44 @@ export class QualityAndOrderRow extends PureComponent<Props> {
     const { onChange, query } = this.props;
 
     onChange({ ...query, maxPageAggregations: +event.currentTarget.value });
+  };
+
+  timeOrderField = () => {
+    const { onChange, query } = this.props;
+
+    // PropertyInterpolated has no time ordering support
+    if (query.queryType === QueryType.PropertyInterpolated) {
+      return null;
+    }
+
+    const onOrderChange = (sel: SelectableValue<SiteWiseTimeOrder>) => {
+      onChange({ ...query, timeOrdering: sel.value });
+    };
+
+    return this.props.newFormStylingEnabled ? (
+      <EditorField label="Time" width={10} htmlFor="time">
+        <Select
+          id="time"
+          aria-label="Time"
+          options={ordering}
+          value={ordering.find((v) => v.value === query.timeOrdering) ?? ordering[0]}
+          onChange={onOrderChange}
+          isSearchable={true}
+          menuPlacement="auto"
+        />
+      </EditorField>
+    ) : (
+      <InlineField htmlFor="time" label="Time" labelWidth={8}>
+        <Select
+          inputId="time"
+          options={ordering}
+          value={ordering.find((v) => v.value === query.timeOrdering) ?? ordering[0]}
+          onChange={onOrderChange}
+          isSearchable={true}
+          menuPlacement="bottom"
+        />
+      </InlineField>
+    );
   };
 
   render() {
@@ -98,17 +132,7 @@ export class QualityAndOrderRow extends PureComponent<Props> {
             menuPlacement="auto"
           />
         </EditorField>
-        <EditorField label="Time" width={10} htmlFor="time">
-          <Select
-            id="time"
-            aria-label="Time"
-            options={ordering}
-            value={ordering.find((v) => v.value === query.timeOrdering) ?? ordering[0]}
-            onChange={this.onOrderChange}
-            isSearchable={true}
-            menuPlacement="auto"
-          />
-        </EditorField>
+        {this.timeOrderField()}
         <EditorField label="Format" width={10} htmlFor="format">
           <Select
             id="format"
@@ -145,16 +169,7 @@ export class QualityAndOrderRow extends PureComponent<Props> {
               menuPlacement="bottom"
             />
           </InlineField>
-          <InlineField htmlFor="time" label="Time" labelWidth={8}>
-            <Select
-              inputId="time"
-              options={ordering}
-              value={ordering.find((v) => v.value === query.timeOrdering) ?? ordering[0]}
-              onChange={this.onOrderChange}
-              isSearchable={true}
-              menuPlacement="bottom"
-            />
-          </InlineField>
+          {this.timeOrderField()}
 
           <InlineField htmlFor="format" label="Format" labelWidth={8}>
             <Select

--- a/src/components/query/QueryEditor.test.tsx
+++ b/src/components/query/QueryEditor.test.tsx
@@ -111,7 +111,6 @@ describe('QueryEditor', () => {
         expect(screen.getByText('Asset')).toBeInTheDocument();
         expect(screen.getByText('Property')).toBeInTheDocument();
         expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Time')).toBeInTheDocument();
         expect(screen.getByText('Format')).toBeInTheDocument();
         expect(screen.getByText('Resolution')).toBeInTheDocument();
       });
@@ -125,7 +124,6 @@ describe('QueryEditor', () => {
       await waitFor(() => {
         expect(screen.getByText('Property Alias')).toBeInTheDocument();
         expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Time')).toBeInTheDocument();
         expect(screen.getByText('Resolution')).toBeInTheDocument();
         expect(screen.getByText('Format')).toBeInTheDocument();
       });

--- a/src/queryInfo.ts
+++ b/src/queryInfo.ts
@@ -38,9 +38,7 @@ export const siteWiseQueryTypes: QueryTypeInfo[] = [
     label: 'Get interpolated property values',
     value: QueryType.PropertyInterpolated,
     description: `Gets interpolated values for an asset property.`,
-    defaultQuery: {
-      timeOrdering: 'ASCENDING',
-    } as AssetPropertyInterpolatedQuery,
+    defaultQuery: {} as AssetPropertyInterpolatedQuery,
     helpURL: 'https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_GetInterpolatedAssetPropertyValues.html',
   },
   {

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,7 +187,6 @@ export function isAssetPropertyAggregatesQuery(q?: SitewiseQuery): q is AssetPro
  */
 export interface AssetPropertyInterpolatedQuery extends SitewiseQuery {
   queryType: QueryType.PropertyInterpolated;
-  timeOrdering?: SiteWiseTimeOrder;
 }
 
 export function isAssetPropertyInterpolatedQuery(q?: SitewiseQuery): q is AssetPropertyInterpolatedQuery {


### PR DESCRIPTION
… id of aggregates

<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
- this PR fixes issues by
  - removed unsupported time ordering from interpolated query
  - cache id of aggregates
- see issues descriptions below

**Which issue(s) this PR fixes**:
1. interpolated query should not support time ordering, see related API https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_GetInterpolatedAssetPropertyValues.html
2. cache id logic was not caching `aggregates`
