### PR TITLE
Migrate to new form styling in config and query editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.3.2",
+    "@grafana/aws-sdk": "0.4.0",
     "@grafana/data": "10.2.0",
     "@grafana/e2e": "10.2.0",
     "@grafana/e2e-selectors": "10.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,10 +21,7 @@ export default defineConfig<PluginOptions>({
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:3000',
-    trace: 'on-first-retry',
-    featureToggles: {
-      awsDatasourcesNewFormStyling: true,
-    }
+    trace: 'on-first-retry'
   },
 
   projects: [

--- a/src/components/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor.test.tsx
@@ -3,7 +3,6 @@ import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { ConfigEditor } from './ConfigEditor';
 import { render, screen } from '@testing-library/react';
 import { SitewiseOptions, SitewiseSecureJsonData } from 'types';
-import { config } from '@grafana/runtime';
 const datasourceOptions = {
   id: 1,
   uid: 'sitewise',
@@ -28,15 +27,6 @@ const defaultProps: DataSourcePluginOptionsEditorProps<SitewiseOptions, Sitewise
   options: datasourceOptions,
   onOptionsChange: jest.fn(),
 };
-const originalToggleValue = config.featureToggles.awsDatasourcesNewFormStyling
-
-describe('ConfigEditor', () => {
-  beforeEach(() => {
-    config.featureToggles.awsDatasourcesNewFormStyling = true;
-  })
- afterEach(() => {
-     config.featureToggles.awsDatasourcesNewFormStyling = originalToggleValue;
- })
   describe('edge configuration', () => {
     it('should show correct fields if Standard authentication', () => {
       render(
@@ -76,4 +66,3 @@ describe('ConfigEditor', () => {
       expect(screen.getByText('Authentication Provider')).toBeInTheDocument();
     });
   });
-});

--- a/src/components/query/ClientCacheRow.tsx
+++ b/src/components/query/ClientCacheRow.tsx
@@ -1,39 +1,24 @@
 import React from 'react';
-import { InlineField, InlineSwitch, Switch } from '@grafana/ui';
+import { Switch } from '@grafana/ui';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 
 interface Props {
   clientCache?: boolean;
-  newFormStylingEnabled?: boolean;
   onClientCacheChange: (evt: React.SyntheticEvent<HTMLInputElement>) => void;
 }
 
-export const ClientCacheRow = ({clientCache, newFormStylingEnabled, onClientCacheChange}: Props) => {
-  if (newFormStylingEnabled) {
-    return (
-      <EditorRow>
-        <EditorFieldGroup>
-          <EditorField
-            label="Client cache"
-            htmlFor="clientCache"
-            tooltip="Enable to cache results in the browser that are older than 15 minutes. This will improve performance for repeated queries with relative time range."
-          >
-            <Switch id="clientCache" value={clientCache} onChange={onClientCacheChange} />
-          </EditorField>
-        </EditorFieldGroup>
-      </EditorRow>
-    );
-  }
-
+export const ClientCacheRow = ({ clientCache, onClientCacheChange }: Props) => {
   return (
-    <div className="gf-form">
-      <InlineField
+    <EditorRow>
+      <EditorFieldGroup>
+        <EditorField
           label="Client cache"
           htmlFor="clientCache"
-          tooltip="Enable to cache results from the query. This will improve performance for repeated queries with relative time range."
-      >
-        <InlineSwitch value={clientCache} onChange={onClientCacheChange} />
-      </InlineField>
-    </div>
+          tooltip="Enable to cache results in the browser that are older than 15 minutes. This will improve performance for repeated queries with relative time range."
+        >
+          <Switch id="clientCache" value={clientCache} onChange={onClientCacheChange} />
+        </EditorField>
+      </EditorFieldGroup>
+    </EditorRow>
   );
 };

--- a/src/components/query/ListAssetsQueryEditor.tsx
+++ b/src/components/query/ListAssetsQueryEditor.tsx
@@ -1,15 +1,10 @@
 import React, { PureComponent } from 'react';
 import { DataFrameView, SelectableValue } from '@grafana/data';
 import { ListAssetsQuery } from 'types';
-import { InlineField, Select } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import { SitewiseQueryEditorProps } from './types';
 import { AssetModelSummary } from 'queryResponseTypes';
-import { firstLabelWith } from './QueryEditor';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
-
-interface Props extends SitewiseQueryEditorProps<ListAssetsQuery> {
-  newFormStylingEnabled?: boolean;
-}
 
 interface State {
   models?: DataFrameView<AssetModelSummary>;
@@ -24,7 +19,7 @@ const filters = [
   { label: 'All', value: 'ALL', description: 'The list includes all assets for a given asset model ID' },
 ];
 
-export class ListAssetsQueryEditor extends PureComponent<Props, State> {
+export class ListAssetsQueryEditor extends PureComponent<SitewiseQueryEditorProps<ListAssetsQuery>, State> {
   state: State = {};
 
   async componentDidMount() {
@@ -63,7 +58,7 @@ export class ListAssetsQueryEditor extends PureComponent<Props, State> {
       };
     }
 
-    return this.props.newFormStylingEnabled ? (
+    return (
       <EditorRow>
         <EditorFieldGroup>
           <EditorField label="Model ID" htmlFor="model" width={30}>
@@ -95,38 +90,6 @@ export class ListAssetsQueryEditor extends PureComponent<Props, State> {
           </EditorField>
         </EditorFieldGroup>
       </EditorRow>
-    ) : (
-      <>
-        <div className="gf-form">
-          <InlineField htmlFor="model" label="Model ID" labelWidth={firstLabelWith} grow={true}>
-            <Select
-              inputId="model"
-              isLoading={!models}
-              options={modelIds}
-              value={currentModel}
-              onChange={this.onAssetModelIdChange}
-              placeholder="Select an asset model id"
-              allowCustomValue={true}
-              isClearable={true}
-              isSearchable={true}
-              formatCreateLabel={(txt) => `Model ID: ${txt}`}
-              menuPlacement="bottom"
-            />
-          </InlineField>
-        </div>
-        <div className="gf-form">
-          <InlineField htmlFor="filter" label="Filter" labelWidth={firstLabelWith} grow={true}>
-            <Select
-              inputId="filter"
-              options={filters}
-              value={filters.find((v) => v.value === query.filter) || filters[0]}
-              onChange={this.onFilterChange}
-              placeholder="Select a property"
-              menuPlacement="bottom"
-            />
-          </InlineField>
-        </div>
-      </>
     );
   }
 }

--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -12,25 +12,19 @@ import {
   ListAssociatedAssetsQuery,
   isListAssociatedAssetsQuery,
   isAssetPropertyInterpolatedQuery,
-  shouldShowLastObserved,
   shouldShowOptionsRow,
-  shouldShowL4eOptions,
 } from 'types';
-import { InlineField, LinkButton, Select, Input, Icon, InlineSwitch } from '@grafana/ui';
+import { LinkButton, Select, Input, Icon } from '@grafana/ui';
 import { SitewiseQueryEditorProps } from './types';
 import { AssetBrowser } from '../browser/AssetBrowser';
 import { AggregatePicker, aggReg } from '../AggregatePicker';
 import { getAssetProperty, getDefaultAggregate } from 'queryInfo';
 import { QualityAndOrderRow } from './QualityAndOrderRow';
-import { firstLabelWith } from './QueryEditor';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import { css } from '@emotion/css';
 import { QueryOptions } from './QueryOptions';
 
-interface Props
-  extends SitewiseQueryEditorProps<SitewiseQuery | AssetPropertyAggregatesQuery | ListAssociatedAssetsQuery> {
-  newFormStylingEnabled?: boolean;
-}
+type Props = SitewiseQueryEditorProps<SitewiseQuery | AssetPropertyAggregatesQuery | ListAssociatedAssetsQuery>;
 
 const resolutions: Array<SelectableValue<SiteWiseResolution>> = [
   {
@@ -232,7 +226,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
   renderAggregateRow(query: AssetPropertyAggregatesQuery) {
     const { property } = this.state;
 
-    return this.props.newFormStylingEnabled ? (
+    return (
       <EditorFieldGroup>
         <EditorField label="Aggregate" htmlFor="aggregate-picker" width={40}>
           <AggregatePicker
@@ -253,27 +247,6 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
           />
         </EditorField>
       </EditorFieldGroup>
-    ) : (
-      <div className="gf-form">
-        <InlineField htmlFor="aggregate-picker" label="Aggregate" labelWidth={firstLabelWith} grow={true}>
-          <AggregatePicker
-            stats={query.aggregates ?? []}
-            onChange={this.onAggregateChange}
-            defaultStat={getDefaultAggregate(property)}
-            menuPlacement="bottom"
-          />
-        </InlineField>
-        <InlineField htmlFor="resolution" label="Resolution" labelWidth={10}>
-          <Select
-            inputId="resolution"
-            width={18}
-            options={resolutions}
-            value={resolutions.find((v) => v.value === query.resolution) || resolutions[0]}
-            onChange={this.onResolutionChange}
-            menuPlacement="bottom"
-          />
-        </InlineField>
-      </div>
     );
   }
 
@@ -296,7 +269,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
         current = query.loadAllChildren ? hierarchies[1] /* all */ : hierarchies[0]; // parent
       }
     }
-    return this.props.newFormStylingEnabled ? (
+    return (
       <EditorField label="Show" htmlFor="show">
         <Select
           id="show"
@@ -315,26 +288,6 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
           menuPlacement="auto"
         />
       </EditorField>
-    ) : (
-      <div className="gf-form">
-        <InlineField label="Show" htmlFor="show" labelWidth={firstLabelWith} grow={true}>
-          <Select
-            inputId="show"
-            isLoading={loading}
-            options={hierarchies}
-            value={current}
-            onChange={this.onHierarchyIdChange}
-            placeholder="Select..."
-            allowCustomValue={true}
-            backspaceRemovesValue={true}
-            isClearable={true}
-            isSearchable={true}
-            onCreateOption={this.onSetHierarchyId}
-            formatCreateLabel={(txt) => `Hierarchy Id: ${txt}`}
-            menuPlacement="bottom"
-          />
-        </InlineField>
-      </div>
     );
   }
 
@@ -388,7 +341,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
       </div>
     );
 
-    return this.props.newFormStylingEnabled ? (
+    return (
       <>
         <EditorRow>
           <EditorField label="Property Alias" tooltip={queryTooltip} tooltipInteractive htmlFor="alias" width={80}>
@@ -490,106 +443,6 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
             </EditorFieldGroup>
           </EditorRow>
         ) : null}
-      </>
-    ) : (
-      <>
-        <div className="gf-form">
-          <InlineField
-            htmlFor="alias"
-            label="Property Alias"
-            labelWidth={firstLabelWith}
-            grow={true}
-            tooltip={queryTooltip}
-            interactive
-          >
-            <Input
-              id="alias"
-              value={query.propertyAlias}
-              onChange={this.onAliasChange}
-              placeholder="optional alias that identifies the property, such as an OPC-UA server data stream path"
-            />
-          </InlineField>
-        </div>
-
-        {!Boolean(query.propertyAlias) && (
-          <>
-            <div className="gf-form">
-              <InlineField htmlFor="asset" label="Asset" labelWidth={firstLabelWith} grow={true}>
-                <Select
-                  inputId="asset"
-                  isMulti={true}
-                  key={query.region ? query.region : 'default'}
-                  isLoading={loading}
-                  options={assets}
-                  value={current}
-                  onChange={(sel) => this.onAssetChange(sel)}
-                  placeholder="Select an asset"
-                  allowCustomValue={true}
-                  isClearable={true}
-                  isSearchable={true}
-                  onCreateOption={this.onSetAssetId}
-                  formatCreateLabel={(txt) => `Asset ID: ${txt}`}
-                  menuPlacement="bottom"
-                />
-              </InlineField>
-
-              <AssetBrowser
-                datasource={datasource}
-                region={query.region}
-                assetId={query.assetIds?.[0]}
-                onAssetChanged={this.onSetAssetId}
-              />
-            </div>
-
-            {showProp && (
-              <div className="gf-form">
-                <InlineField htmlFor="property" label="Property" labelWidth={firstLabelWith} grow={true}>
-                  <Select
-                    inputId="property"
-                    isLoading={loading}
-                    options={assetPropertyOptions}
-                    value={currentAssetPropertyOption ?? null}
-                    onChange={this.onPropertyChange}
-                    placeholder="Select a property"
-                    isSearchable={true}
-                    allowCustomValue={true}
-                    onCreateOption={this.onSetPropertyId}
-                    formatCreateLabel={(txt) => `Property ID: ${txt}`}
-                    menuPlacement="bottom"
-                  />
-                </InlineField>
-
-                {shouldShowLastObserved(query.queryType) && (
-                  <InlineField
-                    label="Expand Time Range"
-                    tooltip="Expand query to include last observed value before the current time range, and next observed value after the time range. "
-                  >
-                    <InlineSwitch value={query.lastObservation} onChange={this.onLastObservationChange} />
-                  </InlineField>
-                )}
-
-                {shouldShowL4eOptions(query.queryType) && (
-                  <InlineField
-                    label="Format L4E Anomaly Result"
-                    htmlFor="l4e"
-                    tooltip="Format query to parse L4E anomaly result."
-                  >
-                    <InlineSwitch value={query.flattenL4e} onChange={this.onFlattenL4eChange} />
-                  </InlineField>
-                )}
-              </div>
-            )}
-          </>
-        )}
-
-        {(showProp || query.propertyAlias) && showQuality && (
-          <>
-            {isAssetPropertyAggregatesQuery(query) && this.renderAggregateRow(query)}
-            <QualityAndOrderRow {...(this.props as any)} />
-          </>
-        )}
-
-        {isAssociatedAssets && this.renderAssociatedAsset(query as ListAssociatedAssetsQuery)}
       </>
     );
   }

--- a/src/components/query/QualityAndOrderRow.tsx
+++ b/src/components/query/QualityAndOrderRow.tsx
@@ -11,17 +11,13 @@ import {
   SiteWiseResponseFormat,
   QueryType,
 } from 'types';
-import { InlineField, Select } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import { SitewiseQueryEditorProps } from './types';
-import { firstLabelWith } from './QueryEditor';
 import { EditorField } from '@grafana/experimental';
 
-interface Props
-  extends SitewiseQueryEditorProps<
-    AssetPropertyValueHistoryQuery | AssetPropertyAggregatesQuery | AssetPropertyInterpolatedQuery
-  > {
-  newFormStylingEnabled?: boolean;
-}
+type Props = SitewiseQueryEditorProps<
+  AssetPropertyValueHistoryQuery | AssetPropertyAggregatesQuery | AssetPropertyInterpolatedQuery
+>;
 
 const interpolatedResolutions: Array<SelectableValue<SiteWiseResolution>> = [
   {
@@ -91,7 +87,7 @@ export class QualityAndOrderRow extends PureComponent<Props> {
       onChange({ ...query, timeOrdering: sel.value });
     };
 
-    return this.props.newFormStylingEnabled ? (
+    return (
       <EditorField label="Time" width={10} htmlFor="time">
         <Select
           id="time"
@@ -103,23 +99,12 @@ export class QualityAndOrderRow extends PureComponent<Props> {
           menuPlacement="auto"
         />
       </EditorField>
-    ) : (
-      <InlineField htmlFor="time" label="Time" labelWidth={8}>
-        <Select
-          inputId="time"
-          options={ordering}
-          value={ordering.find((v) => v.value === query.timeOrdering) ?? ordering[0]}
-          onChange={onOrderChange}
-          isSearchable={true}
-          menuPlacement="bottom"
-        />
-      </InlineField>
     );
   };
 
   render() {
     const { query } = this.props;
-    return this.props.newFormStylingEnabled ? (
+    return (
       <>
         <EditorField label="Quality" width={15} htmlFor="quality">
           <Select
@@ -154,57 +139,6 @@ export class QualityAndOrderRow extends PureComponent<Props> {
             />
           </EditorField>
         )}
-      </>
-    ) : (
-      <>
-        <div className="gf-form">
-          <InlineField htmlFor="quality" label="Quality" labelWidth={firstLabelWith}>
-            <Select
-              inputId="quality"
-              width={20}
-              options={qualities}
-              value={qualities.find((v) => v.value === query.quality) ?? qualities[0]}
-              onChange={this.onQualityChange}
-              isSearchable={true}
-              menuPlacement="bottom"
-            />
-          </InlineField>
-          {this.timeOrderField()}
-
-          <InlineField htmlFor="format" label="Format" labelWidth={8}>
-            <Select
-              inputId="format"
-              value={query.responseFormat || SiteWiseResponseFormat.Table}
-              onChange={this.onResponseFormatChange}
-              options={FORMAT_OPTIONS}
-            />
-          </InlineField>
-
-          {isAssetPropertyInterpolatedQuery(query) && (
-            <InlineField htmlFor="resolution" label="Resolution" labelWidth={10}>
-              <Select
-                inputId="resolution"
-                width={18}
-                options={interpolatedResolutions}
-                value={interpolatedResolutions.find((v) => v.value === query.resolution) || interpolatedResolutions[0]}
-                onChange={this.onResolutionChange}
-                menuPlacement="bottom"
-              />
-            </InlineField>
-          )}
-
-          {/*<InlineField label="Pages per Query" labelWidth={8}>*/}
-          {/*  <Input*/}
-          {/*    type="number"*/}
-          {/*    min="0"*/}
-          {/*    value={query.maxPageAggregations ?? 1}*/}
-          {/*    placeholder="enter a number"*/}
-          {/*    onChange={this.onMaxPageAggregations}*/}
-          {/*    width={8}*/}
-          {/*    css=""*/}
-          {/*  />*/}
-          {/*</InlineField>*/}
-        </div>
       </>
     );
   }

--- a/src/components/query/QueryEditor.test.tsx
+++ b/src/components/query/QueryEditor.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { DataQueryRequest, DataSourceInstanceSettings, QueryEditorProps } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { DataSource } from 'DataSource';
 import { QueryType, SitewiseOptions, SitewiseQuery } from 'types';
 import { QueryEditor } from './QueryEditor';
@@ -23,11 +22,6 @@ const instanceSettings: DataSourceInstanceSettings<SitewiseOptions> = {
   withCredentials: false,
   meta: {} as any,
 };
-const originalFormFeatureToggleValue = config.featureToggles.awsDatasourcesNewFormStyling;
-
-const cleanup = () => {
-  config.featureToggles.awsDatasourcesNewFormStyling = originalFormFeatureToggleValue;
-};
 
 const setup = async (query: Partial<SitewiseQuery>, props = defaultProps) => {
   render(
@@ -39,24 +33,16 @@ const setup = async (query: Partial<SitewiseQuery>, props = defaultProps) => {
       }}
     />
   );
-  if (config.featureToggles.awsDatasourcesNewFormStyling) {
-    await openOptionsCollapse();
-  }
+
+  await openOptionsCollapse();
 };
-jest
-  .spyOn(DataSource.prototype, 'query')
-  .mockImplementation((request: DataQueryRequest<SitewiseQuery>) => of());
+jest.spyOn(DataSource.prototype, 'query').mockImplementation((request: DataQueryRequest<SitewiseQuery>) => of());
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getTemplateSrv: () => ({
     getVariables: () => [],
     replace: (v: string) => v,
   }),
-  config: {
-    featureToggles: {
-      awsDatasourcesNewFormStyling: false,
-    },
-  },
 }));
 const defaultProps: QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions> = {
   datasource: new DataSource(instanceSettings),
@@ -66,278 +52,250 @@ const defaultProps: QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions>
 };
 
 describe('QueryEditor', () => {
-  function run() {
-    it('should display correct fields for query type PropertyAggregate', async () => {
-      await setup({
-        queryType: QueryType.PropertyAggregate,
-        propertyId: 'prop',
-        assetIds: ['asset'],
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-        expect(screen.getByText('Asset')).toBeInTheDocument();
-        expect(screen.getByText('Property')).toBeInTheDocument();
-        expect(screen.getByText('Aggregate')).toBeInTheDocument();
-        expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Resolution')).toBeInTheDocument();
-        expect(screen.getByText('Expand Time Range')).toBeInTheDocument();
-        expect(screen.getByText('Time')).toBeInTheDocument();
-        expect(screen.getByText('Format')).toBeInTheDocument();
-      });
+  it('should display correct fields for query type PropertyAggregate', async () => {
+    await setup({
+      queryType: QueryType.PropertyAggregate,
+      propertyId: 'prop',
+      assetIds: ['asset'],
     });
-
-    it('should display correct fields for query type PropertyAggregate and using Property alias', async () => {
-      await setup({
-        queryType: QueryType.PropertyAggregate,
-        propertyAlias: 'propAlias',
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-        expect(screen.getByText('Aggregate')).toBeInTheDocument();
-        expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Time')).toBeInTheDocument();
-        expect(screen.getByText('Format')).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      expect(screen.getByText('Asset')).toBeInTheDocument();
+      expect(screen.getByText('Property')).toBeInTheDocument();
+      expect(screen.getByText('Aggregate')).toBeInTheDocument();
+      expect(screen.getByText('Quality')).toBeInTheDocument();
+      expect(screen.getByText('Resolution')).toBeInTheDocument();
+      expect(screen.getByText('Expand Time Range')).toBeInTheDocument();
+      expect(screen.getByText('Time')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
     });
-
-    it('should display correct fields for query type Interpolated Property', async () => {
-      await setup({
-        queryType: QueryType.PropertyInterpolated,
-        propertyId: 'prop',
-        assetIds: ['asset'],
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-        expect(screen.getByText('Asset')).toBeInTheDocument();
-        expect(screen.getByText('Property')).toBeInTheDocument();
-        expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Format')).toBeInTheDocument();
-        expect(screen.getByText('Resolution')).toBeInTheDocument();
-      });
-    });
-
-    it('should display correct fields for query type  Interpolated Property and using Property alias', async () => {
-      await setup({
-        queryType: QueryType.PropertyInterpolated,
-        propertyAlias: 'propAlias',
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-        expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Resolution')).toBeInTheDocument();
-        expect(screen.getByText('Format')).toBeInTheDocument();
-      });
-    });
-
-    it('should display correct fields for query type PropertyValueHistory', async () => {
-      await setup({
-        queryType: QueryType.PropertyValueHistory,
-        propertyId: 'prop',
-        assetIds: ['asset'],
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-        expect(screen.getByText('Asset')).toBeInTheDocument();
-        expect(screen.getByText('Property')).toBeInTheDocument();
-        expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Expand Time Range')).toBeInTheDocument();
-        expect(screen.getByText('Format L4E Anomaly Result')).toBeInTheDocument();
-        expect(screen.getByText('Client cache')).toBeInTheDocument();
-        expect(screen.getByText('Time')).toBeInTheDocument();
-        expect(screen.getByText('Format')).toBeInTheDocument();
-      });
-    });
-
-    it('should display correct fields for query type PropertyValueHistory and using Property alias', async () => {
-      await setup({
-        queryType: QueryType.PropertyAggregate,
-        propertyAlias: 'propAlias',
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-        expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Format')).toBeInTheDocument();
-      });
-    });
-
-    it('should display correct fields for query type PropertyValue', async () => {
-      await setup({
-        queryType: QueryType.PropertyValue,
-        propertyId: 'prop',
-        assetIds: ['asset'],
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-        expect(screen.getByText('Asset')).toBeInTheDocument();
-        expect(screen.getByText('Property')).toBeInTheDocument();
-        expect(screen.getByText('Quality')).toBeInTheDocument();
-        expect(screen.getByText('Format L4E Anomaly Result')).toBeInTheDocument();
-        expect(screen.getByText('Client cache')).toBeInTheDocument();
-        expect(screen.getByText('Time')).toBeInTheDocument();
-        expect(screen.getByText('Format')).toBeInTheDocument();
-      });
-    });
-
-    it('should display correct fields for query type PropertyValue and using Property alias', async () => {
-      await setup({
-        queryType: QueryType.PropertyValue,
-        propertyAlias: 'propAlias',
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-        // temporary condition - in the old form version, the following fields are not displayed, but they should be in the new one
-        if (config.featureToggles.awsDatasourcesNewFormStyling) {
-          expect(screen.getByText('Quality')).toBeInTheDocument();
-          expect(screen.getByText('Time')).toBeInTheDocument();
-          expect(screen.getByText('Format')).toBeInTheDocument();
-        } else {
-          expect(screen.queryByText('Quality')).toBeNull();
-          expect(screen.queryByText('Time')).toBeNull();
-          expect(screen.queryByText('Format')).toBeNull();
-        }
-      });
-    });
-
-    it('should display correct fields for query type ListAssets', async () => {
-      await setup({
-        queryType: QueryType.ListAssets,
-        propertyId: 'prop',
-        assetIds: ['asset'],
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Model ID')).toBeInTheDocument();
-        expect(screen.getByText('Filter')).toBeInTheDocument();
-      });
-    });
-
-    it('should display correct fields for query type ListAssociatedAssets if assetId is defined', async () => {
-      await setup({
-        queryType: QueryType.ListAssociatedAssets,
-        assetIds: ['asset'],
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Show')).toBeInTheDocument();
-        expect(screen.getByText('Asset')).toBeInTheDocument();
-        expect(screen.getByText('Property Alias')).toBeInTheDocument();
-      });
-    });
-
-    it('should display correct fields for query type ListAssociatedAssets if property Alias is defined', async () => {
-      await setup({
-        queryType: QueryType.ListAssociatedAssets,
-        propertyAlias: 'prop',
-      });
-      await waitFor(() => {
-        expect(screen.getByText('Show')).toBeInTheDocument();
-      });
-    });
-
-    it('should clear property when the only asset is deselected', async () => {
-      const onChange = jest.fn();
-
-      await setup(
-        {
-          queryType: QueryType.PropertyValue,
-          propertyId: 'prop',
-          assetIds: ['asset'],
-        },
-        {
-          ...defaultProps,
-          onChange,
-        }
-      );
-
-      await waitFor(() => {
-        expect(screen.getAllByRole('button', { name: 'select-clear-value' })[1]).toBeInTheDocument();
-      });
-
-      await userEvent.click(screen.getAllByRole('button', { name: 'select-clear-value' })[1]);
-
-      expect(onChange).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          assetIds: [],
-          propertyId: undefined,
-        })
-      );
-    });
-
-    it('should clear property when all assets are deselected', async () => {
-      const onChange = jest.fn();
-
-      await setup(
-        {
-          queryType: QueryType.PropertyValue,
-          propertyId: 'prop',
-          assetIds: ['asset1', 'asset2', 'asset3'],
-        },
-        {
-          ...defaultProps,
-          onChange,
-        }
-      );
-
-      await waitFor(() => {
-        expect(screen.getAllByRole('button', { name: 'select-clear-value' })[1]).toBeInTheDocument();
-      });
-
-      await userEvent.click(screen.getAllByRole('button', { name: 'select-clear-value' })[1]);
-
-      expect(onChange).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          assetIds: [],
-          propertyId: undefined,
-        })
-      );
-    });
-
-    it('should not clear property when only one of multiple assets is deselected', async () => {
-      const onChange = jest.fn();
-
-      await setup(
-        {
-          queryType: QueryType.PropertyValue,
-          propertyId: 'prop',
-          assetIds: ['asset1', 'asset2', 'asset3'],
-        },
-        {
-          ...defaultProps,
-          onChange,
-        }
-      );
-
-      await waitFor(() => {
-        expect(screen.getAllByRole('button', { name: 'Remove' })[1]).toBeInTheDocument();
-      });
-
-      await userEvent.click(screen.getAllByRole('button', { name: 'Remove' })[1]);
-
-      expect(onChange).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          assetIds: ['asset1', 'asset3'],
-          propertyId: 'prop',
-        })
-      );
-    });
-  }
-
-  describe('QueryEditor with awsDatasourcesNewFormStyling feature toggle disabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = false;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    run();
   });
 
-  describe('QueryEditor with awsDatasourcesNewFormStyling feature toggle enabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = true;
+  it('should display correct fields for query type PropertyAggregate and using Property alias', async () => {
+    await setup({
+      queryType: QueryType.PropertyAggregate,
+      propertyAlias: 'propAlias',
     });
-    afterAll(() => {
-      cleanup();
+    await waitFor(() => {
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      expect(screen.getByText('Aggregate')).toBeInTheDocument();
+      expect(screen.getByText('Quality')).toBeInTheDocument();
+      expect(screen.getByText('Time')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
     });
-    run();
+  });
+
+  it('should display correct fields for query type Interpolated Property', async () => {
+    await setup({
+      queryType: QueryType.PropertyInterpolated,
+      propertyId: 'prop',
+      assetIds: ['asset'],
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      expect(screen.getByText('Asset')).toBeInTheDocument();
+      expect(screen.getByText('Property')).toBeInTheDocument();
+      expect(screen.getByText('Quality')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+      expect(screen.getByText('Resolution')).toBeInTheDocument();
+    });
+  });
+
+  it('should display correct fields for query type  Interpolated Property and using Property alias', async () => {
+    await setup({
+      queryType: QueryType.PropertyInterpolated,
+      propertyAlias: 'propAlias',
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      expect(screen.getByText('Quality')).toBeInTheDocument();
+      expect(screen.getByText('Resolution')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+    });
+  });
+
+  it('should display correct fields for query type PropertyValueHistory', async () => {
+    await setup({
+      queryType: QueryType.PropertyValueHistory,
+      propertyId: 'prop',
+      assetIds: ['asset'],
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      expect(screen.getByText('Asset')).toBeInTheDocument();
+      expect(screen.getByText('Property')).toBeInTheDocument();
+      expect(screen.getByText('Quality')).toBeInTheDocument();
+      expect(screen.getByText('Expand Time Range')).toBeInTheDocument();
+      expect(screen.getByText('Format L4E Anomaly Result')).toBeInTheDocument();
+      expect(screen.getByText('Client cache')).toBeInTheDocument();
+      expect(screen.getByText('Time')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+    });
+  });
+
+  it('should display correct fields for query type PropertyValueHistory and using Property alias', async () => {
+    await setup({
+      queryType: QueryType.PropertyAggregate,
+      propertyAlias: 'propAlias',
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      expect(screen.getByText('Quality')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+    });
+  });
+
+  it('should display correct fields for query type PropertyValue', async () => {
+    await setup({
+      queryType: QueryType.PropertyValue,
+      propertyId: 'prop',
+      assetIds: ['asset'],
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      expect(screen.getByText('Asset')).toBeInTheDocument();
+      expect(screen.getByText('Property')).toBeInTheDocument();
+      expect(screen.getByText('Quality')).toBeInTheDocument();
+      expect(screen.getByText('Format L4E Anomaly Result')).toBeInTheDocument();
+      expect(screen.getByText('Client cache')).toBeInTheDocument();
+      expect(screen.getByText('Time')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+    });
+  });
+
+  it('should display correct fields for query type PropertyValue and using Property alias', async () => {
+    await setup({
+      queryType: QueryType.PropertyValue,
+      propertyAlias: 'propAlias',
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      // temporary condition - in the old form version, the following fields are not displayed, but they should be in the new one
+      expect(screen.getByText('Quality')).toBeInTheDocument();
+      expect(screen.getByText('Time')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+    });
+  });
+
+  it('should display correct fields for query type ListAssets', async () => {
+    await setup({
+      queryType: QueryType.ListAssets,
+      propertyId: 'prop',
+      assetIds: ['asset'],
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Model ID')).toBeInTheDocument();
+      expect(screen.getByText('Filter')).toBeInTheDocument();
+    });
+  });
+
+  it('should display correct fields for query type ListAssociatedAssets if assetId is defined', async () => {
+    await setup({
+      queryType: QueryType.ListAssociatedAssets,
+      assetIds: ['asset'],
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Show')).toBeInTheDocument();
+      expect(screen.getByText('Asset')).toBeInTheDocument();
+      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+    });
+  });
+
+  it('should display correct fields for query type ListAssociatedAssets if property Alias is defined', async () => {
+    await setup({
+      queryType: QueryType.ListAssociatedAssets,
+      propertyAlias: 'prop',
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Show')).toBeInTheDocument();
+    });
+  });
+
+  it('should clear property when the only asset is deselected', async () => {
+    const onChange = jest.fn();
+
+    await setup(
+      {
+        queryType: QueryType.PropertyValue,
+        propertyId: 'prop',
+        assetIds: ['asset'],
+      },
+      {
+        ...defaultProps,
+        onChange,
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'select-clear-value' })[1]).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'select-clear-value' })[1]);
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        assetIds: [],
+        propertyId: undefined,
+      })
+    );
+  });
+
+  it('should clear property when all assets are deselected', async () => {
+    const onChange = jest.fn();
+
+    await setup(
+      {
+        queryType: QueryType.PropertyValue,
+        propertyId: 'prop',
+        assetIds: ['asset1', 'asset2', 'asset3'],
+      },
+      {
+        ...defaultProps,
+        onChange,
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'select-clear-value' })[1]).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'select-clear-value' })[1]);
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        assetIds: [],
+        propertyId: undefined,
+      })
+    );
+  });
+
+  it('should not clear property when only one of multiple assets is deselected', async () => {
+    const onChange = jest.fn();
+
+    await setup(
+      {
+        queryType: QueryType.PropertyValue,
+        propertyId: 'prop',
+        assetIds: ['asset1', 'asset2', 'asset3'],
+      },
+      {
+        ...defaultProps,
+        onChange,
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Remove' })[1]).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Remove' })[1]);
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        assetIds: ['asset1', 'asset3'],
+        propertyId: 'prop',
+      })
+    );
   });
 });
 

--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -3,13 +3,12 @@ import React from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from 'DataSource';
 import { SitewiseQuery, SitewiseOptions, QueryType, ListAssetsQuery } from 'types';
-import { Icon, InlineField, LinkButton, Select } from '@grafana/ui';
+import { Icon, LinkButton, Select } from '@grafana/ui';
 import { QueryTypeInfo, siteWiseQueryTypes, changeQueryType } from 'queryInfo';
 import { standardRegionOptions } from 'regions';
 import { ListAssetsQueryEditor } from './ListAssetsQueryEditor';
 import { PropertyQueryEditor } from './PropertyQueryEditor';
 import { EditorField, EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
-import { config } from '@grafana/runtime';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
 import { ClientCacheRow } from './ClientCacheRow';
 
@@ -24,8 +23,6 @@ const queryDefaults: Partial<SitewiseQuery> = {
 export const firstLabelWith = 20;
 
 export function QueryEditor(props: Props) {
-  const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
-
   const { datasource } = props;
   const query = defaults(props.query, queryDefaults);
 
@@ -53,7 +50,7 @@ export function QueryEditor(props: Props) {
     onChange({ ...query, clientCache: evt.currentTarget.checked });
   };
 
-  const renderQuery = (query: SitewiseQuery, newFormStylingEnabled?: boolean) => {
+  const renderQuery = (query: SitewiseQuery) => {
     if (!query.queryType) {
       return;
     }
@@ -61,19 +58,13 @@ export function QueryEditor(props: Props) {
       case QueryType.ListAssetModels:
         return null; // nothing required
       case QueryType.ListAssets:
-        return (
-          <ListAssetsQueryEditor
-            {...props}
-            query={query as ListAssetsQuery}
-            newFormStylingEnabled={newFormStylingEnabled}
-          />
-        );
+        return <ListAssetsQueryEditor {...props} query={query as ListAssetsQuery} />;
       case QueryType.ListAssociatedAssets:
       case QueryType.PropertyValue:
       case QueryType.PropertyInterpolated:
       case QueryType.PropertyAggregate:
       case QueryType.PropertyValueHistory:
-        return <PropertyQueryEditor {...props} newFormStylingEnabled={newFormStylingEnabled} />;
+        return <PropertyQueryEditor {...props} />;
     }
     return <div>Missing UI for query type: {query.queryType}</div>;
   };
@@ -87,95 +78,49 @@ export function QueryEditor(props: Props) {
     </div>
   ) : undefined;
 
-  const clientCacheRow = <ClientCacheRow clientCache={query.clientCache} newFormStylingEnabled={newFormStylingEnabled} onClientCacheChange={onClientCacheChange}></ClientCacheRow>;
+  const clientCacheRow = (
+    <ClientCacheRow clientCache={query.clientCache} onClientCacheChange={onClientCacheChange}></ClientCacheRow>
+  );
 
   return (
     <>
-      {newFormStylingEnabled ? (
-        <>
-          {props?.app !== 'explore' && (
-            <QueryEditorHeader<DataSource, SitewiseQuery, SitewiseOptions>
-              {...props}
-              enableRunButton
-              showAsyncQueryButtons={false}
-            />
-          )}
-          <EditorRows>
-            <EditorRow>
-              <EditorFieldGroup>
-                <EditorField htmlFor="query" label="Query type" tooltip={queryTooltip} tooltipInteractive width={30}>
-                  <Select
-                    id="query"
-                    aria-label="Query type"
-                    options={siteWiseQueryTypes}
-                    value={currentQueryType}
-                    onChange={onQueryTypeChange}
-                    placeholder="Select query type"
-                    menuPlacement="auto"
-                  />
-                </EditorField>
-                <EditorField label="Region" width={15}>
-                  <Select
-                    options={regions}
-                    value={standardRegionOptions.find((v) => v.value === query.region) || defaultRegion}
-                    onChange={onRegionChange}
-                    backspaceRemovesValue={true}
-                    allowCustomValue={true}
-                    isClearable={true}
-                    menuPlacement="auto"
-                  />
-                </EditorField>
-              </EditorFieldGroup>
-            </EditorRow>
-            {renderQuery(query, true)}
-            {clientCacheRow}
-          </EditorRows>
-        </>
-      ) : (
-        <>
-          {props?.app !== 'explore' && (
-            <QueryEditorHeader<DataSource, SitewiseQuery, SitewiseOptions>
-              {...props}
-              enableRunButton
-              showAsyncQueryButtons={false}
-            />
-          )}
-          <div className="gf-form">
-            <InlineField
-              htmlFor="query"
-              label="Query type"
-              labelWidth={firstLabelWith}
-              grow={true}
-              tooltip={queryTooltip}
-              interactive
-            >
+      {props?.app !== 'explore' && (
+        <QueryEditorHeader<DataSource, SitewiseQuery, SitewiseOptions>
+          {...props}
+          enableRunButton
+          showAsyncQueryButtons={false}
+        />
+      )}
+      <EditorRows>
+        <EditorRow>
+          <EditorFieldGroup>
+            <EditorField htmlFor="query" label="Query type" tooltip={queryTooltip} tooltipInteractive width={30}>
               <Select
-                inputId="query"
+                id="query"
+                aria-label="Query type"
                 options={siteWiseQueryTypes}
                 value={currentQueryType}
                 onChange={onQueryTypeChange}
                 placeholder="Select query type"
-                menuPlacement="bottom"
+                menuPlacement="auto"
               />
-            </InlineField>
-            <InlineField label="Region" labelWidth={14}>
+            </EditorField>
+            <EditorField label="Region" width={15}>
               <Select
-                width={18}
                 options={regions}
                 value={standardRegionOptions.find((v) => v.value === query.region) || defaultRegion}
                 onChange={onRegionChange}
                 backspaceRemovesValue={true}
                 allowCustomValue={true}
                 isClearable={true}
-                menuPlacement="bottom"
+                menuPlacement="auto"
               />
-            </InlineField>
-          </div>
-
-          {renderQuery(query)}
-          {clientCacheRow}
-        </>
-      )}
+            </EditorField>
+          </EditorFieldGroup>
+        </EditorRow>
+        {renderQuery(query)}
+        {clientCacheRow}
+      </EditorRows>
     </>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,10 +2047,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.3.2.tgz#911870a6a43c2cd6fcd28edc32d1a7a848c11395"
-  integrity sha512-ktRaY1wteuC3HJEL+ISS4cFH2Bk2egL9uyVRKaTEEST6ikkb6ug2KxHjWUdrno5KFINElFC4RJ65rHknB3AVSw==
+"@grafana/aws-sdk@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.4.0.tgz#bc5192c48b47ca0911ba2ac777923abd337d1074"
+  integrity sha512-42OBqjb0zgEy1jgteg8llkz55p0r0GZGYxzxfLXHpqGQwqkextUO+axlGjRuylKl50d+XArZEvUNj4JWRGp23w==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
     "@grafana/experimental" "1.7.0"


### PR DESCRIPTION
Removes the newFormStyling feature toggle, making the new styling default. Part of https://github.com/grafana/oss-plugin-partnerships/issues/692