### PR TITLE
Fix: use ReadAuthSettings to get authSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.22.1
+
+- Fix: use ReadAuthSettings to get authSettings in [#333](https://github.com/grafana/iot-sitewise-datasource/pull/333)
+
 ## 1.22.0
 
 - Update to use GetSessionWithAuthSettings [#330](https://github.com/grafana/iot-sitewise-datasource/pull/330)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-sitewise-datasource",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "View IoT Sitewise data in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/sitewise/datasource.go
+++ b/pkg/sitewise/datasource.go
@@ -42,7 +42,7 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	}
 
 	sessions := awsds.NewSessionCache()
-	authSettings, _ := awsds.ReadAuthSettingsFromContext(ctx)
+	authSettings := awsds.ReadAuthSettings(ctx)
 	clientGetter := func(region string) (swclient client.SitewiseClient, err error) {
 		swclient, err = client.GetClient(region, cfg, sessions.GetSessionWithAuthSettings, authSettings)
 		return


### PR DESCRIPTION
Uses ReadAuthSettings which tries to read auth settings from context first and then automatically falls back to reading auth settings from the environment.

Also includes the changes for releasing these changes.