### PR TITLE
feat: add list time series to query editor

### DIFF
--- a/pkg/framer/fields/field_names.go
+++ b/pkg/framer/fields/field_names.go
@@ -18,4 +18,13 @@ const (
 	CompositeModels  = "composite_models"
 	AnomalyScore     = "anomaly_score"
 	PredictionReason = "prediction_reason"
+	Alias    		 = "alias"     		
+	AssetId 		 = "asset_id"       
+	DataType  		 = "dataType"         
+	DataTypeSpec  	 = "dataTypeSpec"    
+	PropertyId  	 = "propertyId" 
+	TimeSeriesArn    = "timeSeriesArn"
+	TimeSeriesId  	 = "timeSeriesId"
+	TimeSeriesCreationDate = "timeSeriesCreationDate"
+	TimeSeriesLastUpdateDate = "timeSeriesLastUpdateDate"
 )

--- a/pkg/framer/fields/fields.go
+++ b/pkg/framer/fields/fields.go
@@ -110,3 +110,41 @@ func PredictionReasonField(length int) *data.Field {
 func DiagnosticField(length int, assetId string) *data.Field {
 	return NewFieldWithName(assetId, data.FieldTypeFloat64, length)
 }
+
+// for time series 
+
+func AliasField(length int) *data.Field {
+	return NewFieldWithName(Alias, data.FieldTypeString, length)
+}
+
+func AssetIdField(length int) *data.Field {
+	return NewFieldWithName(AssetId, data.FieldTypeString, length)
+}
+
+func DataTypeField(length int) *data.Field {
+	return NewFieldWithName(DataType, data.FieldTypeString, length)
+}
+
+func DataTypeSpecField(length int) *data.Field {
+	return NewFieldWithName(DataTypeSpec, data.FieldTypeString, length)
+}
+
+func PropertyIdField(length int) *data.Field {
+	return NewFieldWithName(PropertyId, data.FieldTypeString, length)
+}
+
+func TimeSeriesArnField(length int) *data.Field {
+	return NewFieldWithName(TimeSeriesArn, data.FieldTypeString, length)
+}
+
+func TimeSeriesIdField(length int) *data.Field {
+	return NewFieldWithName(TimeSeriesId, data.FieldTypeString, length)
+}
+
+func TimeSeriesCreationDateField(length int) *data.Field {
+	return NewFieldWithName(TimeSeriesCreationDate, data.FieldTypeTime, length)
+}
+
+func TimeSeriesLastUpdateDateField(length int) *data.Field {
+	return NewFieldWithName(TimeSeriesLastUpdateDate, data.FieldTypeTime, length)
+}

--- a/pkg/framer/list_time_series.go
+++ b/pkg/framer/list_time_series.go
@@ -1,0 +1,104 @@
+package framer
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iotsitewise"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/iot-sitewise-datasource/pkg/framer/fields"
+	"github.com/grafana/iot-sitewise-datasource/pkg/models"
+	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/resource"
+	
+)
+
+type TimeSeries iotsitewise.ListTimeSeriesOutput
+
+type timeSeriesSummaryFields struct {
+	alias         		*data.Field
+	assetId           *data.Field
+	dataType          *data.Field
+	dataTypeSpec      *data.Field
+	propertyId  	 *data.Field
+	timeSeriesArn  *data.Field
+	timeSeriesId  *data.Field
+	timeSeriesCreationDate *data.Field
+	timeSeriesLastUpdateDate  *data.Field
+}
+
+func (f *timeSeriesSummaryFields) fields() data.Fields {
+	return data.Fields{
+		f.alias,    
+		f.assetId,
+		f.dataType,
+		f.dataTypeSpec,
+		f.propertyId,
+		f.timeSeriesArn,
+		f.timeSeriesId,
+		f.timeSeriesCreationDate,
+		f.timeSeriesLastUpdateDate,
+	}
+}
+
+func newTimeSeriesSummaryFields(length int) *timeSeriesSummaryFields {
+	return &timeSeriesSummaryFields{
+		alias:         fields.AliasField(length),
+		assetId:           fields.AssetIdField(length),
+		dataType:          fields.DataTypeField(length),
+		dataTypeSpec:      fields.DataTypeSpecField(length),
+		propertyId:  fields.PropertyIdField(length),
+		timeSeriesArn:  fields.TimeSeriesArnField(length),
+		timeSeriesId:  fields.TimeSeriesIdField(length),
+		timeSeriesCreationDate: fields.TimeSeriesCreationDateField(length),
+		timeSeriesLastUpdateDate:   fields.TimeSeriesLastUpdateDateField(length),
+	}
+}
+
+func (t TimeSeries) Frames(_ context.Context, _ resource.ResourceProvider) (data.Frames, error) {
+
+	length := len(t.TimeSeriesSummaries)
+
+	timeSeriesSummaryFields := newTimeSeriesSummaryFields(length)
+
+	for i, timeSeries := range t.TimeSeriesSummaries {
+
+	
+		if (timeSeries.Alias != nil) {
+			timeSeriesSummaryFields.alias.Set(i, *timeSeries.Alias)
+		} 
+		if (timeSeries.AssetId != nil) {
+			timeSeriesSummaryFields.assetId.Set(i, *timeSeries.AssetId)
+		}
+		if (timeSeries.DataType != nil) {
+			timeSeriesSummaryFields.dataType.Set(i, *timeSeries.DataType)
+		}
+		if (timeSeries.DataTypeSpec != nil) {
+			timeSeriesSummaryFields.dataTypeSpec.Set(i, *timeSeries.DataTypeSpec)
+		}
+		if (timeSeries.PropertyId != nil) {
+			timeSeriesSummaryFields.propertyId.Set(i, *timeSeries.PropertyId)
+		}
+		if (timeSeries.TimeSeriesArn != nil) {
+			timeSeriesSummaryFields.timeSeriesArn.Set(i, *timeSeries.TimeSeriesArn)
+		}
+		if (timeSeries.TimeSeriesId != nil) {
+			timeSeriesSummaryFields.timeSeriesId.Set(i, *timeSeries.TimeSeriesId)
+		}
+		if (timeSeries.TimeSeriesCreationDate != nil) {
+			timeSeriesSummaryFields.timeSeriesCreationDate.Set(i, *timeSeries.TimeSeriesCreationDate)
+		}
+		if (timeSeries.TimeSeriesLastUpdateDate != nil) {
+			timeSeriesSummaryFields.timeSeriesLastUpdateDate.Set(i, *timeSeries.TimeSeriesLastUpdateDate)
+		}
+	}
+
+	frame := data.NewFrame("", timeSeriesSummaryFields.fields()...)
+
+	frame.Meta = &data.FrameMeta{
+		Custom: models.SitewiseCustomMeta{
+			NextToken: aws.StringValue(t.NextToken),
+		},
+	}
+
+	return data.Frames{frame}, nil
+}

--- a/pkg/models/asset.go
+++ b/pkg/models/asset.go
@@ -20,6 +20,13 @@ type ListAssetsQuery struct {
 	Filter  string `json:"filter,omitempty"`
 }
 
+type ListTimeSeriesQuery struct {
+	BaseQuery
+	TimeSeriesType string `json:"timeSeriesType,omitempty"`
+	AssetId        string `json:"assetId,omitempty"`
+	AliasPrefix    string `json:"aliasPrefix,omitempty"`
+}
+
 type ListAssociatedAssetsQuery struct {
 	BaseQuery
 	HierarchyId     string `json:"hierarchyId,omitempty"`
@@ -63,6 +70,18 @@ func GetListAssetsQuery(dq *backend.DataQuery) (*ListAssetsQuery, error) {
 
 	// AssetId <--> AssetIds backward compatibility
 	query.MigrateAssetId()
+
+	// add on the DataQuery params
+	query.MaxDataPoints = dq.MaxDataPoints
+	query.QueryType = dq.QueryType
+	return query, nil
+}
+
+func GetListTimeSeriesQuery(dq *backend.DataQuery) (*ListTimeSeriesQuery, error) {
+	query := &ListTimeSeriesQuery{}
+	if err := json.Unmarshal(dq.JSON, query); err != nil {
+		return nil, err
+	} 
 
 	// add on the DataQuery params
 	query.MaxDataPoints = dq.MaxDataPoints

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -17,6 +17,7 @@ const (
 	QueryTypeDescribeAsset        = "DescribeAsset"
 	QueryTypeDescribeAssetModel   = "DescribeAssetModel"
 	QueryTypeListAssetProperties  = "ListAssetProperties"
+	QueryTypeListTimeSeries       = "ListTimeSeries"
 )
 
 const (

--- a/pkg/server/datasource.go
+++ b/pkg/server/datasource.go
@@ -20,4 +20,5 @@ type Datasource interface {
 	HandleDescribeAssetQuery(ctx context.Context, req *backend.QueryDataRequest, query *models.DescribeAssetQuery) (data.Frames, error)
 	HandleListAssociatedAssetsQuery(ctx context.Context, req *backend.QueryDataRequest, query *models.ListAssociatedAssetsQuery) (data.Frames, error)
 	HandleDescribeAssetModelQuery(ctx context.Context, req *backend.QueryDataRequest, query *models.DescribeAssetModelQuery) (data.Frames, error)
+	HandleListTimeSeriesQuery(ctx context.Context, req *backend.QueryDataRequest, query *models.ListTimeSeriesQuery) (data.Frames, error)
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -49,6 +49,10 @@ func (s *Server) HandleDescribeAsset(ctx context.Context, req *backend.QueryData
 	return processQueries(ctx, req, s.handleDescribeAssetQuery), nil
 }
 
+func (s *Server) HandleListTimeSeries(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return processQueries(ctx, req, s.handleListTimeSeriesQuery), nil
+}
+
 func (s *Server) HandleListAssetProperties(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	return processQueries(ctx, req, s.handleListAssetPropertiesQuery), nil
 }
@@ -220,6 +224,25 @@ func (s *Server) handleListAssociatedAssetsQuery(ctx context.Context, req *backe
 	}
 
 	frames, err := s.Datasource.HandleListAssociatedAssetsQuery(ctx, req, query)
+	if err != nil {
+		return DataResponseErrorRequestFailed(err)
+	}
+
+	return backend.DataResponse{
+		Frames: frames,
+		Error:  nil,
+	}
+}
+
+func (s *Server) handleListTimeSeriesQuery(ctx context.Context, req *backend.QueryDataRequest, q backend.DataQuery) backend.DataResponse {
+	query, err := models.GetListTimeSeriesQuery(&q)
+
+	if err != nil {
+		return DataResponseErrorUnmarshal(err)
+	}
+
+	frames, err := s.Datasource.HandleListTimeSeriesQuery(ctx, req, query)
+	
 	if err != nil {
 		return DataResponseErrorRequestFailed(err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,6 +63,7 @@ func getQueryHandlers(s *Server) *datasource.QueryTypeMux {
 	mux.HandleFunc(models.QueryTypeListAssets, s.HandleListAssets)
 	mux.HandleFunc(models.QueryTypeDescribeAsset, s.HandleDescribeAsset)
 	mux.HandleFunc(models.QueryTypeListAssetProperties, s.HandleListAssetProperties)
+	mux.HandleFunc(models.QueryTypeListTimeSeries, s.HandleListTimeSeries)
 
 	return mux
 }

--- a/pkg/sitewise/api/list_time_series.go
+++ b/pkg/sitewise/api/list_time_series.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iotsitewise"
+
+	"github.com/grafana/iot-sitewise-datasource/pkg/framer"
+	"github.com/grafana/iot-sitewise-datasource/pkg/models"
+	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client"
+	"github.com/grafana/iot-sitewise-datasource/pkg/util"
+	
+)
+
+func ListTimeSeries(ctx context.Context, client client.SitewiseClient, query models.ListTimeSeriesQuery) (*framer.TimeSeries, error) {
+
+	var (
+		timeSeriesType *string
+		assetId *string = util.GetAssetId(query.BaseQuery)
+		aliasPrefix *string
+	)
+
+	if query.TimeSeriesType != "" {
+		// if user wants to see all timeseries data do not filter on type
+		if query.TimeSeriesType == "ALL" { 
+			timeSeriesType = nil
+		} else {
+			timeSeriesType = aws.String(query.TimeSeriesType)
+		}	
+	}
+
+	if query.AliasPrefix != "" {
+		aliasPrefix = aws.String(query.AliasPrefix)
+	}
+
+	if query.TimeSeriesType == "DISASSOCIATED" {
+		// cannot filter on assetId for disassociated data
+		assetId = nil
+	}
+
+	if query.TimeSeriesType == "ASSOCIATED" {
+		// cannot filter by alias prefix on associated data
+		aliasPrefix = nil
+	}
+
+	resp, err := client.ListTimeSeriesWithContext(ctx, &iotsitewise.ListTimeSeriesInput{
+		AssetId: 		assetId,
+		TimeSeriesType: timeSeriesType,
+		AliasPrefix:  	aliasPrefix,
+		MaxResults:   	aws.Int64(250),
+		NextToken:    	getNextToken(query.BaseQuery),
+	})
+
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &framer.TimeSeries{
+		TimeSeriesSummaries: resp.TimeSeriesSummaries,
+		NextToken:      resp.NextToken,
+	}, nil
+}

--- a/pkg/sitewise/datasource.go
+++ b/pkg/sitewise/datasource.go
@@ -210,6 +210,12 @@ func (ds *Datasource) HandleListAssetsQuery(ctx context.Context, req *backend.Qu
 	})
 }
 
+func (ds *Datasource) HandleListTimeSeriesQuery(ctx context.Context, req *backend.QueryDataRequest, query *models.ListTimeSeriesQuery) (data.Frames, error) {
+	return ds.invoke(ctx, req, &query.BaseQuery, func(ctx context.Context, sw client.SitewiseClient) (framer.Framer, error) {
+		return api.ListTimeSeries(ctx, sw, *query)
+	})
+}
+
 func (ds *Datasource) HandleDescribeAssetQuery(ctx context.Context, req *backend.QueryDataRequest, query *models.DescribeAssetQuery) (data.Frames, error) {
 	return ds.invoke(ctx, req, &query.BaseQuery, func(ctx context.Context, sw client.SitewiseClient) (framer.Framer, error) {
 		return api.DescribeAsset(ctx, sw, *query)

--- a/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
@@ -28,6 +28,8 @@ function createSiteWiseQuery(id: number): SitewiseQueriesUnion {
     modelId: `mock-model-${id}`,
     filter: 'ALL',
     aggregates: [AggregateType.AVERAGE],
+    timeSeriesType: "DISASSOCIATED",
+    aliasPrefix: "aws/mock/disassociated"
   };
 }
 
@@ -35,8 +37,8 @@ describe('generateSiteWiseQueriesCacheId()', () => {
   it('parses SiteWise Queries into cache Id', () => {
     const actualId = generateSiteWiseQueriesCacheId([createSiteWiseQuery(1), createSiteWiseQuery(2)]);
     const expectedId = JSON.stringify([
-      '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"]]',
-      '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"]]'
+      '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]',
+      '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]'
     ]);
 
     expect(actualId).toEqual(expectedId);
@@ -83,7 +85,7 @@ describe('generateSiteWiseQueriesCacheId()', () => {
     };
     const actualId = generateSiteWiseQueriesCacheId([query]);
     const expectedId = JSON.stringify([
-      '["ListAssets",null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]',
+      '["ListAssets",null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]',
     ]);
 
     expect(actualId).toEqual(expectedId);
@@ -113,8 +115,8 @@ describe('generateSiteWiseRequestCacheId()', () => {
     const expectedId = JSON.stringify([
       'now-15m',
       JSON.stringify([
-        '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"]]',
-        '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"]]'
+        '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]',
+        '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]'
       ])
     ]);
 

--- a/src/RelativeRangeRequestCache/cacheIdUtils.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.ts
@@ -41,6 +41,8 @@ function generateSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId
     modelId,
     filter,
     aggregates,
+    timeSeriesType,
+    aliasPrefix,
   } = query;
 
   /*
@@ -68,5 +70,7 @@ function generateSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId
     modelId,
     filter,
     aggregates,
+    timeSeriesType,
+    aliasPrefix,
   ]);
 }

--- a/src/RelativeRangeRequestCache/types.ts
+++ b/src/RelativeRangeRequestCache/types.ts
@@ -1,5 +1,5 @@
 import { DataFrame } from '@grafana/data';
-import { AssetPropertyAggregatesQuery, AssetPropertyValueHistoryQuery, ListAssetsQuery, ListAssociatedAssetsQuery, QueryType, SitewiseQuery } from 'types';
+import { AssetPropertyAggregatesQuery, AssetPropertyValueHistoryQuery, ListAssetsQuery, ListAssociatedAssetsQuery, ListTimeSeriesQuery, QueryType, SitewiseQuery } from 'types';
 
 const TIME_SERIES_QUERY_TYPES = new Set<QueryType>([
   QueryType.PropertyAggregate,
@@ -33,4 +33,6 @@ export type SitewiseQueriesUnion = SitewiseQuery
   & Partial<Pick<ListAssociatedAssetsQuery, 'loadAllChildren'>>
   & Partial<Pick<ListAssociatedAssetsQuery, 'hierarchyId'>>
   & Partial<Pick<ListAssetsQuery, 'modelId'>>
-  & Partial<Pick<ListAssetsQuery, 'filter'>>;
+  & Partial<Pick<ListAssetsQuery, 'filter'>>
+  & Partial<Pick<ListTimeSeriesQuery, 'timeSeriesType'>>
+  & Partial<Pick<ListTimeSeriesQuery, 'aliasPrefix'>>;

--- a/src/components/query/ListTimeSeriesQueryEditor.tsx
+++ b/src/components/query/ListTimeSeriesQueryEditor.tsx
@@ -1,0 +1,93 @@
+import React, { ChangeEvent, useState } from 'react';
+import { SelectableValue } from '@grafana/data';
+import { ListTimeSeriesQuery } from 'types';
+import { Input, Select } from '@grafana/ui';
+import { SitewiseQueryEditorProps } from './types';
+import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
+
+
+interface Props extends SitewiseQueryEditorProps<ListTimeSeriesQuery> {
+  newFormStylingEnabled?: boolean;
+}
+
+const timeSeriesTypes = [
+  {
+    label: 'ALL',
+    value: 'ALL',
+    description: 'All time series data',
+  },
+  {
+    label: 'ASSOCIATED',
+    value: 'ASSOCIATED',
+    description: "The time series is associated with an asset property.",
+  },
+  { label: 'DISASSOCIATED', value: 'DISASSOCIATED', description: "The time series isn't associated with any asset property." },
+];
+
+export const ListTimeSeriesQueryEditorFunction = (props: Props) => {
+
+  const [lastInput, setLastInput] = useState<string>()
+
+  const onAliasPrefixChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { onChange, query } = props;
+    setLastInput("prefix")
+    onChange({ ...query, aliasPrefix: e.target.value });
+  };
+
+  const onAssetIdChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { onChange, query } = props;
+    setLastInput("id")
+    onChange({ ...query, assetId: e.target.value });
+  };
+
+  const onTimeSeriesTypeChange = (sel: SelectableValue<string>) => {
+    const { onChange, query } = props;
+    if (sel.value === 'ALL' && lastInput === "prefix"){
+      onChange({ ...query, timeSeriesType: sel.value as 'ASSOCIATED' | 'DISASSOCIATED' | 'ALL' , assetId: undefined});
+    }
+    else if (sel.value === 'ALL' && lastInput === "id"){
+      onChange({ ...query, timeSeriesType: sel.value as 'ASSOCIATED' | 'DISASSOCIATED' | 'ALL' , aliasPrefix: undefined});
+    } else {
+      onChange({ ...query, timeSeriesType: sel.value as 'ASSOCIATED' | 'DISASSOCIATED' | 'ALL' });
+    }
+    
+  };
+
+  const { query } = props;
+  
+  return (
+      <EditorRow>
+        <EditorFieldGroup>
+          <EditorField label="Time Series Type" htmlFor="timeSeriesType" width={20}>
+            <Select
+              inputId="timeSeriesType"
+              options={timeSeriesTypes}
+              value={timeSeriesTypes.find((v: { value: string; }) => v.value === query.timeSeriesType) || timeSeriesTypes[0]}
+              onChange={onTimeSeriesTypeChange}
+              placeholder="Select a property"
+              menuPlacement="auto"
+            />
+          </EditorField>
+          {query.timeSeriesType !== "ASSOCIATED" && <EditorField label="Alias Prefix" htmlFor="aliasPrefix" width={30} tooltip={"The alias prefix of the time series."}>
+            <Input
+              id="aliasPrefix"
+              value={query.aliasPrefix}
+              onChange={onAliasPrefixChange}
+              placeholder="Optional: alias prefix"
+            />
+          </EditorField>}
+          {query.timeSeriesType !== "DISASSOCIATED" && (<EditorField label="Asset Id" htmlFor="assetId" width={30} tooltip={"The ID of the asset in which the asset property was created. This can be either the actual ID in UUID format, or else externalId: followed by the external ID, if it has one"}>
+            <Input
+              id="assetId"
+              value={query.assetId}
+              onChange={onAssetIdChange}
+              placeholder="Optional: asset id"
+            />
+          </EditorField>)}
+        </EditorFieldGroup>
+      </EditorRow>
+    )
+};
+
+
+

--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -2,7 +2,7 @@ import defaults from 'lodash/defaults';
 import React from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from 'DataSource';
-import { SitewiseQuery, SitewiseOptions, QueryType, ListAssetsQuery } from 'types';
+import { SitewiseQuery, SitewiseOptions, QueryType, ListAssetsQuery, ListTimeSeriesQuery } from 'types';
 import { Icon, LinkButton, Select } from '@grafana/ui';
 import { QueryTypeInfo, siteWiseQueryTypes, changeQueryType } from 'queryInfo';
 import { standardRegionOptions } from 'regions';
@@ -11,6 +11,7 @@ import { PropertyQueryEditor } from './PropertyQueryEditor';
 import { EditorField, EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
 import { ClientCacheRow } from './ClientCacheRow';
+import { ListTimeSeriesQueryEditorFunction } from './ListTimeSeriesQueryEditor';
 
 type Props = QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions>;
 
@@ -59,6 +60,8 @@ export function QueryEditor(props: Props) {
         return null; // nothing required
       case QueryType.ListAssets:
         return <ListAssetsQueryEditor {...props} query={query as ListAssetsQuery} />;
+        case QueryType.ListTimeSeries:
+        return <ListTimeSeriesQueryEditorFunction {...props} query={query as ListTimeSeriesQuery} />
       case QueryType.ListAssociatedAssets:
       case QueryType.PropertyValue:
       case QueryType.PropertyInterpolated:

--- a/src/queryInfo.ts
+++ b/src/queryInfo.ts
@@ -14,6 +14,7 @@ import {
   AssetPropertyInfo,
   ListAssociatedAssetsQuery,
   isListAssociatedAssetsQuery,
+  ListTimeSeriesQuery
 } from './types';
 
 export interface QueryTypeInfo extends SelectableValue<QueryType> {
@@ -79,6 +80,13 @@ export const siteWiseQueryTypes: QueryTypeInfo[] = [
     description: 'Retrieves a paginated list of associated assets.',
     defaultQuery: {} as ListAssociatedAssetsQuery,
     helpURL: 'https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssociatedAssets.html',
+  },
+  {
+    label: 'List time series',
+    value: QueryType.ListTimeSeries,
+    description: 'Retrieves a paginated list of time series (data streams)',
+    defaultQuery: {} as ListTimeSeriesQuery,
+    helpURL: 'https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListTimeSeries.html',
   },
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export enum QueryType {
   PropertyValueHistory = 'PropertyValueHistory',
   PropertyAggregate = 'PropertyAggregate',
   PropertyInterpolated = 'PropertyInterpolated',
+  ListTimeSeries = "ListTimeSeries"
 }
 
 export enum SiteWiseQuality {
@@ -191,6 +192,21 @@ export interface AssetPropertyInterpolatedQuery extends SitewiseQuery {
 
 export function isAssetPropertyInterpolatedQuery(q?: SitewiseQuery): q is AssetPropertyInterpolatedQuery {
   return q?.queryType === QueryType.PropertyInterpolated;
+}
+
+/**
+ * {@link https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListTimeSeries.html}
+ */
+
+export interface ListTimeSeriesQuery extends SitewiseQuery {
+  queryType: QueryType.ListTimeSeries;
+  aliasPrefix?: string;
+  assetId?: string;
+  timeSeriesType?: "ASSOCIATED" | "DISASSOCIATED" | "ALL";
+}
+
+export function isListTimeSeriesQuery(q?: SitewiseQuery): q is ListTimeSeriesQuery {
+  return q?.queryType === QueryType.ListTimeSeries;
 }
 
 export function isPropertyQueryType(queryType?: QueryType): boolean {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**: This PR adds the implementation for the listTimeSeries API call in the SitwiseSDK. It extends the query editor with a form that allows users to populate the parameters for the API call correctly.

**Which issue(s) this PR fixes**: Users can now query disassociated data (aka unmodeled data) and filter on assetId or alias prefix for specific data streams.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: