### PR TITLE
Remove ANY option for interpolated property quality

### DIFF
--- a/pkg/sitewise/api/property_interpolated.go
+++ b/pkg/sitewise/api/property_interpolated.go
@@ -37,7 +37,7 @@ func interpolatedQueryToInputs(query models.AssetPropertyValueQuery) []*iotsitew
 	endTimeInSeconds := to.Unix()
 
 	quality := query.Quality
-	if quality == "" {
+	if quality == "" || query.Quality == "ANY" {
 		quality = "GOOD"
 	}
 

--- a/src/components/query/QualityAndOrderRow.tsx
+++ b/src/components/query/QualityAndOrderRow.tsx
@@ -43,6 +43,8 @@ const qualities: Array<SelectableValue<SiteWiseQuality>> = [
   { value: SiteWiseQuality.UNCERTAIN, label: 'UNCERTAIN' },
 ];
 
+const interpolatedPropertyQualities: Array<SelectableValue<SiteWiseQuality>> = qualities.slice(1);
+
 const ordering: Array<SelectableValue<SiteWiseTimeOrder>> = [
   { value: SiteWiseTimeOrder.ASCENDING, label: 'ASCENDING' },
   { value: SiteWiseTimeOrder.DESCENDING, label: 'DESCENDING' },
@@ -104,10 +106,8 @@ export class QualityAndOrderRow extends PureComponent<Props> {
 
   render() {
     const { query } = this.props;
-    let currQualities = qualities;
-    if (query.queryType === QueryType.PropertyInterpolated) {
-      currQualities = qualities.slice(1);
-    }
+    const currQualities =
+      query.queryType === QueryType.PropertyInterpolated ? interpolatedPropertyQualities : qualities;
     return (
       <>
         <EditorField label="Quality" width={15} htmlFor="quality">

--- a/src/components/query/QualityAndOrderRow.tsx
+++ b/src/components/query/QualityAndOrderRow.tsx
@@ -104,9 +104,9 @@ export class QualityAndOrderRow extends PureComponent<Props> {
 
   render() {
     const { query } = this.props;
-    let currQualites = qualities;
+    let currQualities = qualities;
     if (query.queryType === QueryType.PropertyInterpolated) {
-      currQualites = qualities.slice(1);
+      currQualities = qualities.slice(1);
     }
     return (
       <>
@@ -114,8 +114,8 @@ export class QualityAndOrderRow extends PureComponent<Props> {
           <Select
             id="quality"
             aria-label="Quality"
-            options={currQualites}
-            value={currQualites.find((v) => v.value === query.quality) ?? currQualites[0]}
+            options={currQualities}
+            value={currQualities.find((v) => v.value === query.quality) ?? currQualities[0]}
             onChange={this.onQualityChange}
             isSearchable={true}
             menuPlacement="auto"

--- a/src/components/query/QualityAndOrderRow.tsx
+++ b/src/components/query/QualityAndOrderRow.tsx
@@ -104,14 +104,18 @@ export class QualityAndOrderRow extends PureComponent<Props> {
 
   render() {
     const { query } = this.props;
+    let currQualites = qualities;
+    if (query.queryType === QueryType.PropertyInterpolated) {
+      currQualites = qualities.slice(1);
+    }
     return (
       <>
         <EditorField label="Quality" width={15} htmlFor="quality">
           <Select
             id="quality"
             aria-label="Quality"
-            options={qualities}
-            value={qualities.find((v) => v.value === query.quality) ?? qualities[0]}
+            options={currQualites}
+            value={currQualites.find((v) => v.value === query.quality) ?? currQualites[0]}
             onChange={this.onQualityChange}
             isSearchable={true}
             menuPlacement="auto"

--- a/src/components/query/QueryEditor.test.tsx
+++ b/src/components/query/QueryEditor.test.tsx
@@ -111,6 +111,10 @@ describe('QueryEditor', () => {
       expect(screen.getByText('Quality')).toBeInTheDocument();
       expect(screen.getByText('Resolution')).toBeInTheDocument();
       expect(screen.getByText('Format')).toBeInTheDocument();
+
+      // Interpolatged Property queries should not have ANY as the quality default
+      expect(screen.getByText('GOOD')).toBeInTheDocument();
+      expect(screen.queryByText('ANY')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/query/QueryEditor.test.tsx
+++ b/src/components/query/QueryEditor.test.tsx
@@ -112,7 +112,7 @@ describe('QueryEditor', () => {
       expect(screen.getByText('Resolution')).toBeInTheDocument();
       expect(screen.getByText('Format')).toBeInTheDocument();
 
-      // Interpolatged Property queries should not have ANY as the quality default
+      // Interpolated Property queries should not have ANY as the quality default
       expect(screen.getByText('GOOD')).toBeInTheDocument();
       expect(screen.queryByText('ANY')).not.toBeInTheDocument();
     });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
When a "Get interpolated property values" query is used with `Quality` set to `ANY` (which is the default option) it errors because it's not a [valid value for the query](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_GetInterpolatedAssetPropertyValues.html#API_GetInterpolatedAssetPropertyValues_RequestSyntax). This PR removes it from the options for interpolated queries and automatically replaces `ANY` with `GOOD` on the backend (since it works on a first run and by using `GOOD` that's probably in line with users expect)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #326

**Special notes for your reviewer**: