### PR TITLE
Remove unused fields from Get property value query editor

### DIFF
--- a/src/components/query/QueryEditor.test.tsx
+++ b/src/components/query/QueryEditor.test.tsx
@@ -159,11 +159,8 @@ describe('QueryEditor', () => {
       expect(screen.getByText('Property Alias')).toBeInTheDocument();
       expect(screen.getByText('Asset')).toBeInTheDocument();
       expect(screen.getByText('Property')).toBeInTheDocument();
-      expect(screen.getByText('Quality')).toBeInTheDocument();
       expect(screen.getByText('Format L4E Anomaly Result')).toBeInTheDocument();
       expect(screen.getByText('Client cache')).toBeInTheDocument();
-      expect(screen.getByText('Time')).toBeInTheDocument();
-      expect(screen.getByText('Format')).toBeInTheDocument();
     });
   });
 
@@ -174,10 +171,6 @@ describe('QueryEditor', () => {
     });
     await waitFor(() => {
       expect(screen.getByText('Property Alias')).toBeInTheDocument();
-      // temporary condition - in the old form version, the following fields are not displayed, but they should be in the new one
-      expect(screen.getByText('Quality')).toBeInTheDocument();
-      expect(screen.getByText('Time')).toBeInTheDocument();
-      expect(screen.getByText('Format')).toBeInTheDocument();
     });
   });
 

--- a/src/components/query/QueryOptions.tsx
+++ b/src/components/query/QueryOptions.tsx
@@ -1,4 +1,4 @@
-import { SitewiseQuery, shouldShowL4eOptions, shouldShowLastObserved } from 'types';
+import { SitewiseQuery, shouldShowL4eOptions, shouldShowLastObserved, shouldShowQualityAndOrderComponent } from 'types';
 import { CollapsableSection, Switch, useTheme2 } from '@grafana/ui';
 import React from 'react';
 import { EditorField, EditorFieldGroup } from '@grafana/experimental';
@@ -55,7 +55,10 @@ export function QueryOptions({
               <Switch value={query.flattenL4e} onChange={onFlattenL4eChange} />
             </EditorField>
           )}
-          {(showProp || query.propertyAlias) && showQuality && qualityAndOrderComponent}
+          {shouldShowQualityAndOrderComponent(query.queryType) &&
+            (showProp || query.propertyAlias) &&
+            showQuality &&
+            qualityAndOrderComponent}
         </EditorFieldGroup>
       </CollapsableSection>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export enum QueryType {
   PropertyValueHistory = 'PropertyValueHistory',
   PropertyAggregate = 'PropertyAggregate',
   PropertyInterpolated = 'PropertyInterpolated',
-  ListTimeSeries = "ListTimeSeries"
+  ListTimeSeries = 'ListTimeSeries',
 }
 
 export enum SiteWiseQuality {
@@ -202,7 +202,7 @@ export interface ListTimeSeriesQuery extends SitewiseQuery {
   queryType: QueryType.ListTimeSeries;
   aliasPrefix?: string;
   assetId?: string;
-  timeSeriesType?: "ASSOCIATED" | "DISASSOCIATED" | "ALL";
+  timeSeriesType?: 'ASSOCIATED' | 'DISASSOCIATED' | 'ALL';
 }
 
 export function isListTimeSeriesQuery(q?: SitewiseQuery): q is ListTimeSeriesQuery {
@@ -233,6 +233,10 @@ export function shouldShowOptionsRow(query: SitewiseQuery, showProp: boolean): b
 
 export function shouldShowL4eOptions(queryType?: QueryType): boolean {
   return queryType === QueryType.PropertyValue || queryType === QueryType.PropertyValueHistory;
+}
+
+export function shouldShowQualityAndOrderComponent(queryType?: QueryType): boolean {
+  return queryType !== QueryType.PropertyValue;
 }
 
 // matches native sitewise API with capitals

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -37,12 +37,6 @@ test.describe('Query Editor', () => {
 
       await queryEditor.selectProperty('Total Average Power');
 
-      await queryEditor.openQueryOptions();
-
-      await expect(queryEditor.qualitySelect).toBeVisible();
-      await expect(queryEditor.timeSelect).toBeVisible();
-      await expect(queryEditor.formatSelect).toBeVisible();
-
       await queryEditor.runQuery();
 
       await expect(page.getByText('No data')).not.toBeVisible();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
Removes unused fields from `Get property value` query editor

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #328

**Special notes for your reviewer**: