### PR TITLE
fix: migrate asset id on the frontend in the query editor

### DIFF
--- a/src/components/query/QueryEditor.tsx
+++ b/src/components/query/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import defaults from 'lodash/defaults';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from 'SitewiseDataSource';
 import { SitewiseQuery, SitewiseOptions, QueryType, ListAssetsQuery, ListTimeSeriesQuery } from 'types';
@@ -8,6 +8,7 @@ import { QueryTypeInfo, siteWiseQueryTypes, changeQueryType } from 'queryInfo';
 import { standardRegionOptions } from 'regions';
 import { ListAssetsQueryEditor } from './ListAssetsQueryEditor';
 import { PropertyQueryEditor } from './PropertyQueryEditor';
+import { migrateQuery } from '../../migrations/migrateQuery';
 import { EditorField, EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
 import { ClientCacheRow } from './ClientCacheRow';
@@ -26,6 +27,14 @@ export const firstLabelWith = 20;
 export function QueryEditor(props: Props) {
   const { datasource } = props;
   const query = defaults(props.query, queryDefaults);
+
+  useEffect(() => {
+    const migratedQuery = migrateQuery(query);
+
+    if (query !== migratedQuery) {
+      props.onChange(migratedQuery);
+    }
+  }, [query.assetId]);
 
   const defaultRegion: SelectableValue<string> = {
     label: `Default`,

--- a/src/migrations/migrateQuery.test.ts
+++ b/src/migrations/migrateQuery.test.ts
@@ -1,0 +1,17 @@
+import { QueryType, SitewiseQuery } from '../types';
+import { migrateQuery } from './migrateQuery';
+
+describe('migrateQuery()', () => {
+  it('should return the same query by reference equality if there are no migrations', () => {
+    const query: SitewiseQuery = { refId: 'a', queryType: QueryType.PropertyAggregate };
+    const migratedQuery = migrateQuery(query);
+    expect(query).toBe(migratedQuery);
+  });
+
+  it('should migrate assetId to assetIds if assetIds does not exist', () => {
+    const query: SitewiseQuery = { refId: 'a', queryType: QueryType.PropertyAggregate, assetId: 'asset-id' };
+    const migratedQuery = migrateQuery(query);
+    expect(query).not.toBe(migratedQuery);
+    expect(migratedQuery.assetIds).toEqual(expect.arrayContaining(['asset-id']));
+  });
+});

--- a/src/migrations/migrateQuery.ts
+++ b/src/migrations/migrateQuery.ts
@@ -1,0 +1,15 @@
+import { SitewiseQuery } from '../types';
+
+const migrateAssetId = (query: SitewiseQuery): SitewiseQuery => {
+  if (query.assetId && !query.assetIds) {
+    return { ...query, assetIds: [query.assetId] };
+  }
+
+  return query;
+};
+
+export const migrateQuery = (query: SitewiseQuery): SitewiseQuery => {
+  let migratedQuery = migrateAssetId(query);
+
+  return migratedQuery;
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

Fixes an issue where dashboards saved with versions before 1.6.0 do not show the selected asset in the query editor after updating to versions 1.6.0+.

The change in 1.6.0 migrated the `asset id` to `asset ids` only when the query ran, but the query editor still received the old query with only the `assetId` field populated so it couldn't fetch the asset info correctly.

This PR adds a very basic migration function that is called from the query editor. The only migration it implements now is to migrate `assetId` to `assetIds`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #238

**Special notes for your reviewer**:

I downgraded the SiteWise data source to v1.5.1 on my cloud instance and created a dashboard with a query type that includes the Asset selector. Then I exported the dashboard and imported it locally to test the migration.