### PR TITLE
Fix golangci-lint errors

### DIFF
--- a/pkg/models/setting.go
+++ b/pkg/models/setting.go
@@ -22,7 +22,7 @@ type AWSSiteWiseDataSourceSetting struct {
 }
 
 func (s *AWSSiteWiseDataSourceSetting) Load(config backend.DataSourceInstanceSettings) error {
-	if config.JSONData != nil && len(config.JSONData) > 1 {
+	if len(config.JSONData) > 1 {
 		if err := json.Unmarshal(config.JSONData, s); err != nil {
 			return fmt.Errorf("could not unmarshal DatasourceSettings json: %w", err)
 		}

--- a/pkg/sitewise/auth.go
+++ b/pkg/sitewise/auth.go
@@ -70,7 +70,7 @@ func (a *EdgeAuthenticator) Authenticate() (models.AuthInfo, error) {
 				for i, asn1Data := range rawCerts {
 					cert, err := x509.ParseCertificate(asn1Data)
 					if err != nil {
-						return fmt.Errorf("tls: failed to parse certificate from server: " + err.Error())
+						return fmt.Errorf("tls: failed to parse certificate from server: %w", err)
 					}
 					certs[i] = cert
 				}


### PR DESCRIPTION
cleanup errors from running `golangci-lint run --timeout=5m`