### PR TITLE
Chore: group dependabot updates on weekly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    ignore:
-      - dependency-name: '@grafana/e2e*'
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
     groups:
       all-node-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: '@grafana/e2e*'
       - dependency-name: 'react'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-dom'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,28 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
+  - package-ecosystem: 'gomod'
+    directory: '/'
     schedule:
-      interval: "weekly"
-    allow:
-      # Keep the sdk modules up-to-date
-      - dependency-name: "github.com/grafana/grafana-plugin-sdk-go"
-        dependency-type: "all"
-    commit-message:
-      prefix: "Upgrade grafana-plugin-sdk-go "
-      include: "scope"
+      interval: 'weekly'
+    groups:
+      all-go-dependencies:
+        patterns:
+          - '*'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all-github-action-dependencies:
+        patterns:
+          - '*'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@grafana/e2e*'
+    groups:
+      all-node-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
- Groups updates according to the package ecosystem
- Sets update interval to be weekly (this will be Mondays by default)

I realized we never updated dependabot for this repo

Fixes: https://github.com/grafana/oss-plugin-partnerships/issues/927