### PR TITLE
feat: support asset selection by external id

### DIFF
--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -181,8 +181,8 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
       this.setState({ assetId: undefined });
       onChange({ ...query, assetIds: undefined });
     } else {
-      const assetIds =
-        uuidRegex.test(assetId) || assetId.startsWith('externalId:') ? [assetId] : [`externalId:${assetId}`];
+      const validId = uuidRegex.test(assetId) || assetId.startsWith('externalId:') || assetId.startsWith('$');
+      const assetIds = validId ? [assetId] : [`externalId:${assetId}`];
       this.setState({ assetId: assetIds[0] });
       onChange({ ...query, assetIds });
     }

--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -358,6 +358,19 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
       </div>
     );
 
+    const assetTooltip = (
+      <div>
+        Set the asset ID. It can be either the actual ID in UUID format, or else "externalId:" followed by the external
+        ID, if it has one.
+        <LinkButton
+          href="https://docs.aws.amazon.com/iot-sitewise/latest/userguide/object-ids.html#external-ids"
+          target="_blank"
+        >
+          API Docs <Icon name="external-link-alt" />
+        </LinkButton>
+      </div>
+    );
+
     return (
       <>
         <EditorRow>
@@ -376,7 +389,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
           <>
             <EditorRow>
               <EditorFieldGroup>
-                <EditorField label="Asset" htmlFor="asset" width={30}>
+                <EditorField label="Asset" tooltip={assetTooltip} tooltipInteractive htmlFor="asset" width={30}>
                   <Select
                     id="asset"
                     inputId="asset"


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the user is required to input only the asset id in uuid format in order to select the asset in a query. If any user tries to enter an [external id](https://docs.aws.amazon.com/iot-sitewise/latest/userguide/object-ids.html#external-ids), the query will not be able to find timeseries data since the dataplane does not support external ids yet.

This change allows users to select assets by external ids and retrieve the timeseries data.

https://github.com/user-attachments/assets/6a5b1e78-2c18-4a98-9e7b-c5a9871a2789

In addition, a tooltip for the asset field teaches users how to enter the asset id. Users can learn more about SiteWise external ids by clicking on the API docs button.

![AssetTooltip](https://github.com/user-attachments/assets/ca3016ca-9add-4eb7-b1c0-57faafd97819)

**Which issue(s) this PR fixes**:

Fixes #351

**Testing**:
- Unit tests passing
- Manually testing these steps:
  - Typing in `externalId:...` retrieves the correct asset
  - Typing in the assetId in uuid format retrieves the correct asset (no change from previous behavior)
  - Typing in a string not in uuid format appends the `externalId:` prefix to retrieve the correct asset
  - Running queries on all three user inputs above loads the correct data
  - Successfully loads asset in query variable