### PR TITLE
fix: list associated assets query fields

### DIFF
--- a/src/components/query/PropertyQueryEditor.tsx
+++ b/src/components/query/PropertyQueryEditor.tsx
@@ -270,10 +270,10 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
       }
     }
     return (
-      <EditorField label="Show" htmlFor="show">
+      <EditorField label="Asset Hierarchy" htmlFor="assetHierarchy">
         <Select
-          id="show"
-          aria-label="Show"
+          id="assetHierarchy"
+          aria-label="Asset Hierarchy"
           isLoading={loading}
           options={hierarchies}
           value={current}
@@ -343,19 +343,21 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
 
     return (
       <>
-        <EditorRow>
-          <EditorField label="Property Alias" tooltip={queryTooltip} tooltipInteractive htmlFor="alias" width={80}>
-            <Input
-              id="alias"
-              aria-label="Property alias"
-              value={query.propertyAlias}
-              onChange={this.onAliasChange}
-              placeholder="optional alias that identifies the property, such as an OPC-UA server data stream path"
-            />
-          </EditorField>
-        </EditorRow>
+        {!isAssociatedAssets && (
+          <EditorRow>
+            <EditorField label="Property Alias" tooltip={queryTooltip} tooltipInteractive htmlFor="alias" width={80}>
+              <Input
+                id="alias"
+                aria-label="Property alias"
+                value={query.propertyAlias}
+                onChange={this.onAliasChange}
+                placeholder="optional alias that identifies the property, such as an OPC-UA server data stream path"
+              />
+            </EditorField>
+          </EditorRow>
+        )}
 
-        {!Boolean(query.propertyAlias) && (
+        {(!Boolean(query.propertyAlias) || isAssociatedAssets) && (
           <>
             <EditorRow>
               <EditorFieldGroup>

--- a/src/components/query/QueryEditor.test.tsx
+++ b/src/components/query/QueryEditor.test.tsx
@@ -192,15 +192,15 @@ describe('QueryEditor', () => {
     });
   });
 
-  it('should display correct fields for query type ListAssociatedAssets if assetId is defined', async () => {
+  it('should display correct fields for query type ListAssociatedAssets', async () => {
     await setup({
       queryType: QueryType.ListAssociatedAssets,
       assetIds: ['asset'],
     });
     await waitFor(() => {
-      expect(screen.getByText('Show')).toBeInTheDocument();
+      expect(screen.getByText('Asset Hierarchy')).toBeInTheDocument();
       expect(screen.getByText('Asset')).toBeInTheDocument();
-      expect(screen.getByText('Property Alias')).toBeInTheDocument();
+      expect(screen.queryByText('Property Alias')).toBeNull();
     });
   });
 
@@ -210,7 +210,9 @@ describe('QueryEditor', () => {
       propertyAlias: 'prop',
     });
     await waitFor(() => {
-      expect(screen.getByText('Show')).toBeInTheDocument();
+      expect(screen.getByText('Asset Hierarchy')).toBeInTheDocument();
+      expect(screen.getByText('Asset')).toBeInTheDocument();
+      expect(screen.queryByText('Property Alias')).toBeNull();
     });
   });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Problem: The "List associated assets" query has a field for property alias but this is not supported in the API. When the property alias is set, the required asset field disappears.

Solution: Removing the property alias field and making sure the asset field is always visible for the "List associated assets" query (even if the property alias is set in another query) will solve this issue.

The query does use the hierarchy id, which is in the field called "Show." As this is confusing for users, I'm changing this field label to "Asset Hierarchy."

https://github.com/user-attachments/assets/6c3b9a28-ba75-4f9d-b884-c61c12496150

**Which issue(s) this PR fixes**:

Fixes #334

**Testing**:
- Unit tests
- Manually testing:
  - Property alias field is never showing when query type is "List associated assets"
  - When property alias is defined elsewhere, the asset field does not disappear
  - Running this query works for hierarchy field set to "Parent", "All", and any hierarchies associated with the selected asset