### PR TITLE
Bugfix: Filter out invalid queries in variable editor

### DIFF
--- a/src/SitewiseDataSource.test.ts
+++ b/src/SitewiseDataSource.test.ts
@@ -2,7 +2,7 @@ import { DataSource } from './SitewiseDataSource';
 import { DataSourceInstanceSettings, PluginMeta, ScopedVar, ScopedVars } from '@grafana/data';
 import { QueryType, SitewiseOptions, SitewiseQuery } from './types';
 
-const testInstanceSettings = (
+export const testInstanceSettings = (
   overrides?: Partial<DataSourceInstanceSettings<SitewiseOptions>>
 ): DataSourceInstanceSettings<SitewiseOptions> => ({
   id: 1,

--- a/src/variables.test.ts
+++ b/src/variables.test.ts
@@ -1,0 +1,69 @@
+import { CoreApp, DataQueryRequest, dateTime } from '@grafana/data';
+import { DataSource } from 'SitewiseDataSource';
+import { testInstanceSettings } from 'SitewiseDataSource.test';
+import { QueryType, SitewiseQuery } from 'types';
+import { SitewiseVariableSupport } from 'variables';
+import { of } from 'rxjs';
+
+const mockedDatasourceQuery = jest.fn().mockReturnValue(of({ data: [] }));
+
+describe('template variable support', () => {
+  describe('query filtering', () => {
+    const mockDatasource = new DataSource(testInstanceSettings());
+    mockDatasource.query = mockedDatasourceQuery;
+    const variableSupport = new SitewiseVariableSupport(mockDatasource);
+    test.each([
+      { refId: 'A', queryType: QueryType.PropertyInterpolated },
+      { refId: 'A', queryType: QueryType.PropertyInterpolated, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.PropertyAggregate },
+      { refId: 'A', queryType: QueryType.PropertyAggregate, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.PropertyValueHistory },
+      { refId: 'A', queryType: QueryType.PropertyValueHistory, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.PropertyValue },
+      { refId: 'A', queryType: QueryType.PropertyValue, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.ListAssetModels },
+      { refId: 'A', queryType: QueryType.ListAssociatedAssets },
+      { refId: 'A', queryType: QueryType.ListAssets },
+    ])('Filters out queries that are missing any required fields', (query: SitewiseQuery) => {
+      const request: DataQueryRequest<SitewiseQuery> = {
+        targets: [query],
+        range: { from: dateTime(), to: dateTime(), raw: { from: dateTime(), to: dateTime() } },
+        interval: '1s',
+        intervalMs: 1000,
+        scopedVars: {},
+        timezone: 'UTC',
+        requestId: '1',
+        app: CoreApp.Dashboard,
+        startTime: 1234567890,
+      };
+      variableSupport.query(request);
+      expect(mockedDatasourceQuery).not.toHaveBeenCalled();
+    });
+    test.each([
+      { refId: 'A', queryType: QueryType.PropertyInterpolated, assetIds: ['assetId'], propertyId: 'propertyId' },
+      { refId: 'A', queryType: QueryType.PropertyAggregate, assetIds: ['assetId'], propertyId: 'propertyId' },
+      { refId: 'A', queryType: QueryType.PropertyValueHistory, assetIds: ['assetId'], propertyId: 'propertyId' },
+      { refId: 'A', queryType: QueryType.PropertyValue, assetIds: ['assetId'], propertyId: 'propertyId' },
+      { refId: 'A', queryType: QueryType.ListAssetModels, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.ListAssociatedAssets, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.ListAssets, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.ListTimeSeries },
+      { refId: 'A', queryType: QueryType.ListTimeSeries },
+    ])('Does not filter out queries that have all the required data', (query: SitewiseQuery) => {
+      jest.clearAllMocks();
+      const request: DataQueryRequest<SitewiseQuery> = {
+        targets: [query],
+        range: { from: dateTime(), to: dateTime(), raw: { from: dateTime(), to: dateTime() } },
+        interval: '1s',
+        intervalMs: 1000,
+        scopedVars: {},
+        timezone: 'UTC',
+        requestId: '1',
+        app: CoreApp.Dashboard,
+        startTime: 1234567890,
+      };
+      variableSupport.query(request);
+      expect(mockedDatasourceQuery).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { assign } from 'lodash';
 import { QueryType, SitewiseQuery } from './types';
@@ -17,15 +17,19 @@ export class SitewiseVariableSupport extends CustomVariableSupport<DataSource, S
   editor = QueryEditor;
 
   query(request: DataQueryRequest<SitewiseQuery>): Observable<DataQueryResponse> {
-    assign(request.targets, [{ ...request.targets[0], refId: 'A' }]);
-    const response = this.datasource.query(request);
-    switch (request.targets[0].queryType) {
-      case QueryType.ListAssetModels:
-      case QueryType.ListAssets:
-      case QueryType.ListAssociatedAssets:
-        return this.parseOptions(response);
-      default:
-        return response;
+    if (this.isValidQuery(request.targets[0])) {
+      assign(request.targets, [{ ...request.targets[0], refId: 'A' }]);
+      const response = this.datasource.query(request);
+      switch (request.targets[0].queryType) {
+        case QueryType.ListAssetModels:
+        case QueryType.ListAssets:
+        case QueryType.ListAssociatedAssets:
+          return this.parseOptions(response);
+        default:
+          return response;
+      }
+    } else {
+      return of({ data: [], error: { message: 'Invalid query' } });
     }
   }
 
@@ -48,5 +52,21 @@ export class SitewiseVariableSupport extends CustomVariableSupport<DataSource, S
         return { data: newData };
       })
     );
+  }
+
+  private isValidQuery(query: SitewiseQuery): boolean {
+    switch (query.queryType) {
+      case QueryType.PropertyValue:
+      case QueryType.PropertyValueHistory:
+      case QueryType.PropertyInterpolated:
+      case QueryType.PropertyAggregate:
+        return Boolean((query.assetIds?.length || query.assetId) && query.propertyId);
+      case QueryType.ListAssetModels:
+      case QueryType.ListAssets:
+      case QueryType.ListAssociatedAssets:
+        return Boolean(query.assetIds?.length);
+      default:
+        return true;
+    }
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

Template variable feature runs queries on change. This causes misleading errors for users, as [here](https://github.com/grafana/iot-sitewise-datasource/issues/398). This filters out queries in variable support for Sitewise so that only queries with defined required fields are run. 
(For queries in panels and explore, those have already been set up so they don't run automatically.)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/iot-sitewise-datasource/issues/398

**Special notes for your reviewer**: