### PR TITLE
fix: isValidQuery broken for listAssets and listAssetModels

### DIFF
--- a/src/variables.test.ts
+++ b/src/variables.test.ts
@@ -35,7 +35,6 @@ describe('SiteWiseVariableSupport', () => {
       { refId: 'A', queryType: QueryType.PropertyValueHistory, assetIds: ['assetId'] },
       { refId: 'A', queryType: QueryType.PropertyValue },
       { refId: 'A', queryType: QueryType.PropertyValue, assetIds: ['assetId'] },
-      { refId: 'A', queryType: QueryType.ListAssetModels },
       { refId: 'A', queryType: QueryType.ListAssociatedAssets },
       { refId: 'A', queryType: QueryType.ListAssets },
     ])('Filters out queries that are missing any required fields', (query: SitewiseQuery) => {
@@ -47,9 +46,9 @@ describe('SiteWiseVariableSupport', () => {
       { refId: 'A', queryType: QueryType.PropertyAggregate, assetIds: ['assetId'], propertyId: 'propertyId' },
       { refId: 'A', queryType: QueryType.PropertyValueHistory, assetIds: ['assetId'], propertyId: 'propertyId' },
       { refId: 'A', queryType: QueryType.PropertyValue, assetIds: ['assetId'], propertyId: 'propertyId' },
-      { refId: 'A', queryType: QueryType.ListAssetModels, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.ListAssetModels },
       { refId: 'A', queryType: QueryType.ListAssociatedAssets, assetIds: ['assetId'] },
-      { refId: 'A', queryType: QueryType.ListAssets, assetIds: ['assetId'] },
+      { refId: 'A', queryType: QueryType.ListAssets, modelId: 'modelId', filter: 'ALL' },
       { refId: 'A', queryType: QueryType.ListTimeSeries },
       { refId: 'A', queryType: QueryType.ListTimeSeries },
     ])('Does not filter out queries that have all the required data', (query: SitewiseQuery) => {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,7 +1,7 @@
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { assign } from 'lodash';
-import { QueryType, SitewiseQuery } from './types';
+import { ListAssetsQuery, QueryType, SitewiseQuery } from './types';
 import { DataSource } from './SitewiseDataSource';
 import { DataQueryRequest, DataQueryResponse, CustomVariableSupport, DataFrameView } from '@grafana/data';
 import { QueryEditor } from './components/query/QueryEditor';
@@ -61,10 +61,14 @@ export class SitewiseVariableSupport extends CustomVariableSupport<DataSource, S
       case QueryType.PropertyInterpolated:
       case QueryType.PropertyAggregate:
         return Boolean((query.assetIds?.length || query.assetId) && query.propertyId);
-      case QueryType.ListAssetModels:
       case QueryType.ListAssets:
+        const listAssetsQuery = query as ListAssetsQuery;
+        return Boolean(
+          (listAssetsQuery.filter === 'ALL' && listAssetsQuery.modelId) || listAssetsQuery.filter === 'TOP_LEVEL'
+        );
       case QueryType.ListAssociatedAssets:
         return Boolean(query.assetIds?.length);
+      case QueryType.ListAssetModels:
       case QueryType.ListTimeSeries:
       case QueryType.DescribeAsset:
       case QueryType.ListAssetProperties:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix isValidQuery logic to not require asset IDs for `listAssets` and `listAssetModels` queries

Before it was expecting a list of assetIDs even though [the listAssets API](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssets.html) and [the listAssetModels API](https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssetModels.html) did not require it

screenshot of feature working again:
<img width="686" alt="image" src="https://github.com/user-attachments/assets/fd3508b4-e806-4ae6-9cfe-88d3102c34b3" />

