### PR TITLE
Feat: Add support for 15min resolution; Improve UI in dropdowns for variables and add support for variables in Resolution

### DIFF
--- a/pkg/server/test/property_values_for_time_range_test.go
+++ b/pkg/server/test/property_values_for_time_range_test.go
@@ -156,7 +156,7 @@ func Test_propertyValueForTimeRange_1h_data_for_time_range(t *testing.T) {
 			{
 				RefID:         "A",
 				QueryType:     models.QueryTypePropertyAggregate,
-				TimeRange:     backend.TimeRange{From: testdata.OneDay, To: testdata.Now},
+				TimeRange:     backend.TimeRange{From: testdata.FifteenDays, To: testdata.Now},
 				MaxDataPoints: 720,
 				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
 					BaseQuery: models.BaseQuery{
@@ -434,7 +434,7 @@ func Test_propertyValueForTimeRange_1h_data_for_time_range_from_alias(t *testing
 			{
 				RefID:         "A",
 				QueryType:     models.QueryTypePropertyAggregate,
-				TimeRange:     backend.TimeRange{From: testdata.OneDay, To: testdata.Now},
+				TimeRange:     backend.TimeRange{From: testdata.FifteenDays, To: testdata.Now},
 				MaxDataPoints: 720,
 				JSON: testdata.SerializeStruct(t, models.AssetPropertyValueQuery{
 					BaseQuery: models.BaseQuery{

--- a/pkg/sitewise/api/propvals/resolution_picker.go
+++ b/pkg/sitewise/api/propvals/resolution_picker.go
@@ -15,14 +15,15 @@ const (
 	maxInterpolatedResponseSize = 10
 	maxInterpolatedPagesToLoad  = 10 // 100-200ms * 10 = 2s max on average ?
 
-	ResolutionRaw        = "RAW"
-	ResolutionSecond     = "1s"
-	ResolutionTenSeconds = "10s"
-	ResolutionMinute     = "1m"
-	ResolutionTenMinutes = "10m"
-	ResolutionHour       = "1h"
-	ResolutionTenHours   = "10h"
-	ResolutionDay        = "1d"
+	ResolutionRaw            = "RAW"
+	ResolutionSecond         = "1s"
+	ResolutionTenSeconds     = "10s"
+	ResolutionMinute         = "1m"
+	ResolutionTenMinutes     = "10m"
+	ResolutionFifteenMinutes = "15m"
+	ResolutionHour           = "1h"
+	ResolutionTenHours       = "10h"
+	ResolutionDay            = "1d"
 )
 
 func roundUp(num float64) int64 {
@@ -38,6 +39,8 @@ func durationForTimeRange(resolution string, timeRange backend.TimeRange) float6
 		return timeRange.Duration().Minutes()
 	} else if ResolutionTenMinutes == resolution {
 		return timeRange.Duration().Minutes() / 10
+	} else if ResolutionFifteenMinutes == resolution {
+		return timeRange.Duration().Minutes() / 15
 	} else if ResolutionHour == resolution {
 		return timeRange.Duration().Hours()
 	} else if ResolutionTenHours == resolution {
@@ -63,7 +66,7 @@ func Resolution(query models.BaseQuery) string {
 	timeRange := query.TimeRange
 	maxDp := query.MaxDataPoints
 
-	for _, resolution := range []string{ResolutionSecond, ResolutionMinute, ResolutionHour} {
+	for _, resolution := range []string{ResolutionSecond, ResolutionMinute, ResolutionFifteenMinutes, ResolutionHour} {
 		pages := pagesForResolution(resolution, timeRange, maxHistoryResponseSize)
 		dps := dataPointsForResolution(resolution, timeRange)
 		// TODO: once '1s' resolution is supported, will need to add threshold for determining
@@ -100,6 +103,8 @@ func ResolutionToDuration(resolution string) time.Duration {
 		return time.Minute
 	case ResolutionTenMinutes:
 		return 10 * time.Minute
+	case ResolutionFifteenMinutes:
+		return 15 * time.Minute
 	case ResolutionHour:
 		return time.Hour
 	case ResolutionTenHours:

--- a/pkg/sitewise/api/propvals/resolution_picker_test.go
+++ b/pkg/sitewise/api/propvals/resolution_picker_test.go
@@ -1,11 +1,12 @@
 package propvals
 
 import (
+	"testing"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/iot-sitewise-datasource/pkg/models"
 	"github.com/grafana/iot-sitewise-datasource/pkg/testdata"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type scenario struct {
@@ -34,10 +35,19 @@ var scenarios = []scenario{
 		expected: ResolutionMinute,
 	},
 	{
+		// dps = 120, pages = 1
+		name: "selects '15m' resolution",
+		query: models.BaseQuery{
+			TimeRange:     backend.TimeRange{From: testdata.OneDay, To: testdata.Now},
+			MaxDataPoints: 720,
+		},
+		expected: ResolutionFifteenMinutes,
+	},
+	{
 		// dps = 24, pages = 1
 		name: "selects '1h' resolution",
 		query: models.BaseQuery{
-			TimeRange:     backend.TimeRange{From: testdata.OneDay, To: testdata.Now},
+			TimeRange:     backend.TimeRange{From: testdata.FifteenDays, To: testdata.Now},
 			MaxDataPoints: 720,
 		},
 		expected: ResolutionHour,

--- a/pkg/testdata/time.go
+++ b/pkg/testdata/time.go
@@ -9,5 +9,6 @@ var (
 	TwoHours    = Now.Add(-2 * time.Hour)
 	FiveMinutes = Now.Add(-5 * time.Minute)
 	OneDay      = Now.Add(-24 * time.Hour)
+	FifteenDays = Now.Add(-15 * 24 * time.Hour)
 	OneMonth    = Now.Add(-24 * 31 * time.Hour)
 )

--- a/src/SitewiseDataSource.ts
+++ b/src/SitewiseDataSource.ts
@@ -10,7 +10,7 @@ import {
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
 import { SitewiseCache } from 'sitewiseCache';
-import { SitewiseQuery, SitewiseOptions, isPropertyQueryType } from './types';
+import { SitewiseQuery, SitewiseOptions, isPropertyQueryType, SiteWiseResolution } from './types';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { frameToMetricFindValues } from 'utils';
@@ -136,6 +136,9 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
       propertyId: templateSrv.replace(query.propertyId || '', scopedVars),
       assetId: templateSrv.replace(query.assetId || '', scopedVars),
       assetIds: query.assetIds?.flatMap((assetId) => templateSrv.replace(assetId, scopedVars, 'csv').split(',')) ?? [],
+      resolution: query.resolution
+        ? (templateSrv.replace(query.resolution, scopedVars) as SiteWiseResolution)
+        : undefined,
     };
   }
 

--- a/src/common/getSelectionInfo.ts
+++ b/src/common/getSelectionInfo.ts
@@ -1,0 +1,55 @@
+import { SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+
+export interface SelectionInfo<T> {
+  options: Array<SelectableValue<T>>;
+  current?: SelectableValue<T>;
+}
+
+const handleValueNotFound = <T = any>(value: T, showNotFound = true) => {
+  const current = {
+    label: `${value} ${showNotFound ? '(not found)' : ''}`,
+    value,
+  };
+  if (current.label!.indexOf('$') >= 0) {
+    current.label = `${value}`;
+    const escaped = getTemplateSrv().replace(String(value));
+    if (escaped !== current.label) {
+      current.label += ` (variable)`;
+    } else {
+      current.label += ` ${escaped}`;
+    }
+  }
+  return current;
+};
+
+export function getSelectionInfo<T>(
+  v?: T,
+  options?: Array<SelectableValue<T>>,
+  templateVars?: Array<SelectableValue<T>>,
+  allowCustom?: boolean
+): SelectionInfo<T> {
+  if (v && !options) {
+    const current = { label: `${v}`, value: v };
+    return { options: [current], current };
+  }
+  if (!options) {
+    options = [];
+  }
+  let current = options.find((item) => item.value === v);
+  if (templateVars) {
+    if (!current) {
+      current = templateVars.find((item) => item.value === v);
+    }
+    options = [{ label: 'Use template variable', options: templateVars, icon: 'link-h' }, ...options];
+  }
+
+  if (v && !current) {
+    current = handleValueNotFound(v, false);
+    options.push(current);
+  }
+  return {
+    options,
+    current,
+  };
+}

--- a/src/common/getVariableOptions.ts
+++ b/src/common/getVariableOptions.ts
@@ -1,0 +1,20 @@
+import { getTemplateSrv } from '@grafana/runtime';
+import { SelectableValue } from '@grafana/data';
+
+interface VariableOptions {
+  hideValue?: boolean;
+  keepVarSyntax?: boolean;
+}
+
+export const getVariableOptions = (opts?: VariableOptions) => {
+  const templateSrv = getTemplateSrv();
+  return templateSrv.getVariables().map((t) => {
+    const label = '${' + t.name + '}';
+    const info: SelectableValue<string> = {
+      label: opts?.hideValue ? `${label}` : `${label} = ${templateSrv.replace(label)}`,
+      value: opts?.keepVarSyntax ? label : t.name,
+      icon: 'arrow-right', // not sure what makes the most sense
+    };
+    return info;
+  });
+};

--- a/src/components/query/AggregationSettings/AggregatePicker.tsx
+++ b/src/components/query/AggregationSettings/AggregatePicker.tsx
@@ -39,7 +39,7 @@ export class AggregatePicker extends PureComponent<Props> {
     this.checkInput();
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate() {
     this.checkInput();
   }
 

--- a/src/components/query/AggregationSettings/AggregationSettings.tsx
+++ b/src/components/query/AggregationSettings/AggregationSettings.tsx
@@ -1,0 +1,70 @@
+import React, { useMemo } from 'react';
+import { SelectableValue } from '@grafana/data';
+import { AggregateType, SiteWiseResolution, AssetPropertyAggregatesQuery, AssetPropertyInfo } from 'types';
+import { Select } from '@grafana/ui';
+import { EditorField, EditorFieldGroup } from '@grafana/plugin-ui';
+import { getDefaultAggregate } from 'queryInfo';
+import { AggregatePicker } from 'components/query/AggregationSettings/AggregatePicker';
+import { getSelectionInfo } from 'common/getSelectionInfo';
+import { getVariableOptions } from 'common/getVariableOptions';
+
+const RESOLUTIONS: Array<SelectableValue<string>> = [
+  {
+    value: SiteWiseResolution.Auto as string,
+    label: 'Auto',
+    description:
+      'Picks a resolution based on the time window. ' +
+      'Will switch to raw data if higher than 1m resolution is needed',
+  },
+  { value: SiteWiseResolution.Min as string, label: 'Minute', description: '1 point every minute' },
+  { value: SiteWiseResolution.FifteenMin as string, label: '15 Minutes', description: '1 point every 15 minutes' },
+  { value: SiteWiseResolution.Hour as string, label: 'Hour', description: '1 point every hour' },
+  { value: SiteWiseResolution.Day as string, label: 'Day', description: '1 point every day' },
+];
+
+export const AggregationSettings = ({
+  onChange,
+  query,
+  property,
+}: {
+  query: AssetPropertyAggregatesQuery;
+  onChange: (value: AssetPropertyAggregatesQuery) => void;
+  property?: AssetPropertyInfo;
+}) => {
+  const onAggregateChange = (aggregates: AggregateType[]) => {
+    onChange({ ...query, aggregates });
+  };
+
+  const onResolutionChange = (sel: SelectableValue<string>) => {
+    onChange({ ...query, resolution: sel.value as SiteWiseResolution });
+  };
+
+  const resolution = useMemo(
+    () => getSelectionInfo(query.resolution, RESOLUTIONS, getVariableOptions({ keepVarSyntax: true })),
+    [query]
+  );
+
+  return (
+    <EditorFieldGroup>
+      <EditorField label="Aggregate" htmlFor="aggregate-picker" width={40}>
+        <AggregatePicker
+          stats={query.aggregates ?? []}
+          onChange={onAggregateChange}
+          defaultStat={getDefaultAggregate(property)}
+          menuPlacement="auto"
+        />
+      </EditorField>
+      <EditorField label="Resolution" htmlFor="resolution" width={25}>
+        <Select
+          inputId="resolution"
+          aria-label="resolution"
+          options={resolution.options}
+          value={resolution.current}
+          onChange={onResolutionChange}
+          allowCustomValue
+          menuPlacement="auto"
+        />
+      </EditorField>
+    </EditorFieldGroup>
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export enum SiteWiseResolution {
   TenSec = '10s',
   Min = '1m',
   TenMin = '10m',
+  FifteenMin = '15m',
   Hour = '1h',
   TenHour = '10h',
   Day = '1d',


### PR DESCRIPTION
Add support for 15m resolution as well as ability to utilize resolution as a template variable.

![Screenshot 2025-02-24 at 1 39 01 PM](https://github.com/user-attachments/assets/5f922dd1-1022-412d-847a-6165356b15fe)

**What this PR does / why we need it**:
Add's in the ability for users to utilize template variables for resolution. Makes it easier for power users to construct dynamic dashboards. Resolves a direct ask of a customer, and works towards the end goal of the plugin which is support for _all_ query parameters to support template variables

**Which issue(s) this PR fixes**:

Fixes #422 

**Special notes for your reviewer**:

- I utilize a UX pattern established in the Grafana Twinmaker app repo in how the variables are surfaced in the inputs. The code can be seen at https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/common/info/info.ts#L151-L180. I utilized this code with minimal changes. You can see the resulting UX below:

![Screenshot 2025-02-24 at 12 34 44 PM](https://github.com/user-attachments/assets/97914aaa-426d-482f-8901-cd363d7712d6)
![Screenshot 2025-02-24 at 12 34 39 PM](https://github.com/user-attachments/assets/81016a34-91a7-4322-bf23-96d904e5c158)

The goal is to have all inputs move towards this UX incrementally. It helps prevent the variable inputs from being overwhelming when a user is not explicitly searching for a variable. 

- 15m support is added as an explicit option, as well as within support for AUTO resolution.
- Refactored Aggregation settings outside of the "Master" query editor file. Long term we should break up the Query editors to avoid having one mega query editor file. 
- The existing unit tests are minimal for the QueryEditor component. Will come back and add improved testing in this area in a follow up.
