### PR TITLE
feat: Support nested variable UX for modelId

### DIFF
--- a/src/common/useOptionsWithVariables.ts
+++ b/src/common/useOptionsWithVariables.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { getSelectionInfo } from './getSelectionInfo';
+import { getVariableOptions } from './getVariableOptions';
+import { SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+
+export const useOptionsWithVariables = ({
+  current,
+  options,
+}: {
+  current?: string;
+  options: SelectableValue<string>[];
+}) => {
+  const variableOptions = getVariableOptions({ keepVarSyntax: true });
+  const variables = getTemplateSrv().getVariables();
+  return useMemo(() => getSelectionInfo(current, options, variableOptions), [current, variables, options]);
+};

--- a/src/components/query/AggregationSettings/AggregationSettings.tsx
+++ b/src/components/query/AggregationSettings/AggregationSettings.tsx
@@ -1,12 +1,11 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { SelectableValue } from '@grafana/data';
 import { AggregateType, SiteWiseResolution, AssetPropertyAggregatesQuery, AssetPropertyInfo } from 'types';
 import { Select } from '@grafana/ui';
 import { EditorField, EditorFieldGroup } from '@grafana/plugin-ui';
 import { getDefaultAggregate } from 'queryInfo';
 import { AggregatePicker } from 'components/query/AggregationSettings/AggregatePicker';
-import { getSelectionInfo } from 'common/getSelectionInfo';
-import { getVariableOptions } from 'common/getVariableOptions';
+import { useOptionsWithVariables } from 'common/useOptionsWithVariables';
 
 const RESOLUTIONS: Array<SelectableValue<string>> = [
   {
@@ -31,6 +30,8 @@ export const AggregationSettings = ({
   onChange: (value: AssetPropertyAggregatesQuery) => void;
   property?: AssetPropertyInfo;
 }) => {
+  const resolution = useOptionsWithVariables({ current: query.resolution, options: RESOLUTIONS });
+
   const onAggregateChange = (aggregates: AggregateType[]) => {
     onChange({ ...query, aggregates });
   };
@@ -38,11 +39,6 @@ export const AggregationSettings = ({
   const onResolutionChange = (sel: SelectableValue<string>) => {
     onChange({ ...query, resolution: sel.value as SiteWiseResolution });
   };
-
-  const resolution = useMemo(
-    () => getSelectionInfo(query.resolution, RESOLUTIONS, getVariableOptions({ keepVarSyntax: true })),
-    [query]
-  );
 
   return (
     <EditorFieldGroup>


### PR DESCRIPTION
**What this PR does / why we need it**:
Utilizes new "nested template variable" UX in dropdown for modelId on the ListAssetQuery editor.

To help improve UX, and UX consistency.

![Screenshot 2025-02-26 at 10 38 20 AM](https://github.com/user-attachments/assets/d56cdf08-b7f6-4206-b1bf-160d34fb7ca0)


**Which issue(s) this PR fixes**:
N/A

Fixes #

**Special notes for your reviewer**:
- Reactivity bug

There is a minor reactivity bug for template variable values to flow down to the dropdown, where if a user changes the variables, it isn't immediately reflected in a dropdown.

This is a reactivity bug that is present already, a bit of a niche case that should be resolved but I think will require a larger refactor of dataflow to turn template variables to be passed in higher in the component tree that I want to tackle seperately.

- Cache refactor

I want to work towards uncoupling the caching module from options. To keep caching just about caching the resources, and have different area handle converting that data to options. This will be incremental work.

Also working on moving towards hook based helpers to remove the need for state management and memoization logic within the query editors.