### PR TITLE
fix: remove unsupported regions

### DIFF
--- a/src/SitewiseDataSource.test.ts
+++ b/src/SitewiseDataSource.test.ts
@@ -58,7 +58,7 @@ describe('Sitewise Datasource', () => {
         assetIds: [],
         propertyAlias: '',
         resolution: '${resolution}' as SiteWiseResolution,
-        region: 'default',
+        region: '',
         propertyId: '',
       };
 
@@ -80,7 +80,7 @@ describe('Sitewise Datasource', () => {
         assetId: '',
         assetIds: ['${assetIdConstant}'],
         propertyAlias: '',
-        region: 'default',
+        region: '',
         propertyId: '',
       };
 
@@ -98,7 +98,7 @@ describe('Sitewise Datasource', () => {
         assetId: '',
         assetIds: ['${assetIdArray}'],
         propertyAlias: '',
-        region: 'default',
+        region: '',
         propertyId: '',
       };
 
@@ -116,7 +116,7 @@ describe('Sitewise Datasource', () => {
         assetIds: ['${assetIdConstant}', '${assetIdArray}'],
         assetId: '',
         propertyAlias: '',
-        region: 'default',
+        region: '',
         propertyId: '',
       };
 
@@ -134,7 +134,7 @@ describe('Sitewise Datasource', () => {
         assetId: '',
         assetIds: ['${assetIdConstant}'],
         propertyAlias: '',
-        region: 'default',
+        region: '',
         propertyId: '',
       };
 
@@ -156,7 +156,7 @@ describe('Sitewise Datasource', () => {
         assetId: '',
         assetIds: ['${assetIdConstant}', 'noVar', '${assetIdArray}'],
         propertyAlias: '',
-        region: 'default',
+        region: '',
         propertyId: '',
       };
 

--- a/src/SitewiseQueryEditor.tsx
+++ b/src/SitewiseQueryEditor.tsx
@@ -8,7 +8,7 @@ import { SitewiseQuery, SitewiseOptions, QueryType } from 'types';
 import { DataSource } from 'SitewiseDataSource';
 import { RawQueryEditor } from 'components/query/query-editor-raw/RawQueryEditor';
 import { VisualQueryBuilder } from 'components/query/visual-query-builder/VisualQueryBuilder';
-import { standardRegionOptions } from 'regions';
+import { regionOptions, type Region } from 'regions';
 
 type Props = QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions>;
 
@@ -25,9 +25,13 @@ export function SitewiseQueryEditor(props: Props) {
     onChange({ ...newQuery, editorMode: newEditorMode });
   };
 
-  const onRegionChange = (sel: SelectableValue<string>) => {
+  const onRegionChange = (sel: SelectableValue<Region>) => {
     onChange({ ...query, region: sel.value });
   };
+
+  const selectedRegionOption = regionOptions.find((option) => {
+    return option.value === query.region;
+  });
 
   return (
     <>
@@ -39,10 +43,8 @@ export function SitewiseQueryEditor(props: Props) {
           editorMode == QueryEditorMode.Code ? (
             <InlineSelect
               label="AWS Region"
-              options={standardRegionOptions}
-              value={
-                standardRegionOptions.find((v) => v.value === query.region) || props.datasource.options.defaultRegion
-              }
+              options={regionOptions}
+              value={selectedRegionOption}
               onChange={onRegionChange}
               backspaceRemovesValue
               allowCustomValue

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -10,8 +10,11 @@ import {
 import { SitewiseOptions, SitewiseSecureJsonData } from '../types';
 import { ConnectionConfig, ConnectionConfigProps, Divider } from '@grafana/aws-sdk';
 import { Alert, Button, Field, Input, Select } from '@grafana/ui';
-import { standardRegions } from '../regions';
+import { supportedRegions } from '../regions';
 import { ConfigSection } from '@grafana/plugin-ui';
+
+// safely remove readonly to please prop types expecting mutable list
+const standardRegions = supportedRegions.map((r) => r);
 
 export type Props = ConnectionConfigProps<SitewiseOptions, SitewiseSecureJsonData>;
 
@@ -25,6 +28,7 @@ export function ConfigEditor(props: Props) {
   if (props.options.jsonData.defaultRegion === 'Edge') {
     return <EdgeConfig {...props} />;
   }
+
   return (
     <div className="width-30">
       <ConnectionConfig {...props} standardRegions={standardRegions} />{' '}
@@ -39,7 +43,7 @@ function EdgeConfig(props: Props) {
 
   const edgeAuthMode = edgeAuthMethods.find((f) => f.value === jsonData.edgeAuthMode) ?? edgeAuthMethods[0];
   const hasEdgeAuth = edgeAuthMode !== edgeAuthMethods[0];
-  const regions = standardRegions.map((value) => ({ value, label: value }));
+  const regions = supportedRegions.map((value) => ({ value, label: value }));
 
   const onUserChange = (event: ChangeEvent<HTMLInputElement>) => {
     updateDatasourcePluginJsonDataOption(props, 'edgeAuthUser', event.target.value);

--- a/src/components/browser/AssetBrowser.tsx
+++ b/src/components/browser/AssetBrowser.tsx
@@ -5,11 +5,12 @@ import { DataSource } from 'SitewiseDataSource';
 import { SitewiseCache } from 'sitewiseCache';
 import { BrowseModels } from './BrowseModels';
 import { BrowseHierarchy } from './BrowseHierarchy';
+import { type Region } from '../../regions';
 
 export interface Props {
   datasource: DataSource;
   assetId?: string; // The incoming value
-  region?: string;
+  region?: Region;
   onAssetChanged: (assetId?: string) => void;
 }
 

--- a/src/components/query/visual-query-builder/PropertyQueryEditor.tsx
+++ b/src/components/query/visual-query-builder/PropertyQueryEditor.tsx
@@ -21,6 +21,7 @@ import { css } from '@emotion/css';
 import { QueryOptions } from './QueryOptions';
 import { AggregationSettings } from './AggregationSettings/AggregationSettings';
 import { InterpolatedResolutionSettings } from './InterpolatedResolutionSettings';
+import { DEFAULT_REGION } from '../../../regions';
 
 type Props = SitewiseQueryEditorProps<SitewiseQuery>;
 
@@ -340,7 +341,7 @@ export class PropertyQueryEditor extends PureComponent<Props, State> {
                     inputId="asset"
                     aria-label="Asset"
                     isMulti={true}
-                    key={query.region ? query.region : 'default'}
+                    key={query.region ?? DEFAULT_REGION}
                     isLoading={loading}
                     options={assets}
                     value={current}

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.test.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.test.tsx
@@ -46,7 +46,7 @@ jest.mock('@grafana/runtime', () => ({
 }));
 const defaultProps: QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions> = {
   datasource: new DataSource(instanceSettings),
-  query: { refId: 'A', queryType: QueryType.DescribeAsset, region: 'default' },
+  query: { refId: 'A', queryType: QueryType.DescribeAsset },
   onRunQuery: jest.fn(),
   onChange: jest.fn(),
 };

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
@@ -5,7 +5,7 @@ import { DataSource } from 'SitewiseDataSource';
 import { SitewiseQuery, SitewiseOptions, QueryType, ListAssetsQuery, ListTimeSeriesQuery } from 'types';
 import { Icon, LinkButton, Select } from '@grafana/ui';
 import { QueryTypeInfo, siteWiseQueryTypes, changeQueryType } from 'queryInfo';
-import { standardRegionOptions } from 'regions';
+import { regionOptions, type Region } from 'regions';
 import { ListAssetsQueryEditor } from './ListAssetsQueryEditor';
 import { PropertyQueryEditor } from './PropertyQueryEditor';
 import { migrateQuery } from '../../../migrations/migrateQuery';
@@ -35,12 +35,12 @@ export function VisualQueryBuilder(props: Props) {
     }
   }, [query.assetId]);
 
-  const defaultRegion: SelectableValue<string> = {
+  const defaultRegion: SelectableValue<Region> = {
     label: `Default`,
     description: datasource.options?.defaultRegion,
     value: undefined,
   };
-  const regions = query.region ? [defaultRegion, ...standardRegionOptions] : standardRegionOptions;
+  const regions = query.region ? [defaultRegion, ...regionOptions] : regionOptions;
   const currentQueryType = siteWiseQueryTypes.find((v) => v.value === query.queryType);
 
   const onQueryTypeChange = (sel: SelectableValue<QueryType>) => {
@@ -49,7 +49,7 @@ export function VisualQueryBuilder(props: Props) {
     onChange(changeQueryType(query, sel as QueryTypeInfo));
   };
 
-  const onRegionChange = (sel: SelectableValue<string>) => {
+  const onRegionChange = (sel: SelectableValue<Region>) => {
     const { onChange, query } = props;
     onChange({ ...query, assetId: undefined, propertyId: undefined, region: sel.value });
   };
@@ -113,7 +113,7 @@ export function VisualQueryBuilder(props: Props) {
             <EditorField label="Region" width={15}>
               <Select
                 options={regions}
-                value={standardRegionOptions.find((v) => v.value === query.region) || defaultRegion}
+                value={regionOptions.find((v) => v.value === query.region) || defaultRegion}
                 onChange={onRegionChange}
                 backspaceRemovesValue={true}
                 allowCustomValue={true}

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -1,35 +1,36 @@
-import { SelectableValue } from '@grafana/data';
+import { type SelectableValue } from '@grafana/data';
 
-export const standardRegions = [
-  'ap-east-1',
-  'ap-northeast-1',
-  'ap-northeast-2',
-  'ap-northeast-3',
+// see https://docs.aws.amazon.com/general/latest/gr/iot-sitewise.html#iot-sitewise_region-sdk
+// order based on order in documentation link
+export const supportedRegions = [
+  'us-east-2',
+  'us-east-1',
+  'us-west-2',
   'ap-south-1',
+  'ap-northeast-2',
   'ap-southeast-1',
   'ap-southeast-2',
+  'ap-northeast-1',
   'ca-central-1',
-  'cn-north-1',
-  'cn-northwest-1',
   'eu-central-1',
-  'eu-north-1',
   'eu-west-1',
-  'eu-west-2',
-  'eu-west-3',
-  'me-south-1',
-  'sa-east-1',
-  'us-east-1',
-  'us-east-2',
-  'us-gov-east-1',
   'us-gov-west-1',
-  'us-iso-east-1',
-  'us-isob-east-1',
-  'us-west-1',
-  'us-west-2',
+  'cn-north-1',
   'Edge',
-];
+] as const;
 
-export const standardRegionOptions: Array<SelectableValue<string>> = standardRegions.map((v) => ({
+// backend is configured to use the user's configured default region when /query
+// is called with an empty string for the region
+export const DEFAULT_REGION = '';
+
+export type DefaultRegion = typeof DEFAULT_REGION;
+
+export type Region = (typeof supportedRegions)[number] | DefaultRegion;
+
+export const regionOptions = supportedRegions.map((v) => ({
   value: v,
   label: v,
-}));
+})) satisfies SelectableValue<Region>[];
+
+export const isSupportedRegion = (region: Region | string | unknown): region is Region =>
+  Boolean(supportedRegions.find((supportedRegion) => supportedRegion === region));

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -6,6 +6,7 @@ import { AssetInfo, AssetPropertyInfo } from './types';
 import { map } from 'rxjs/operators';
 import { getTemplateSrv } from '@grafana/runtime';
 import { useEffect, useState } from 'react';
+import { type Region } from './regions';
 
 /**
  * Keep a different cache for each region
@@ -18,7 +19,7 @@ export class SitewiseCache {
 
   constructor(
     private ds: DataSource,
-    private region: string
+    private region: Region
   ) {}
 
   async getAssetInfo(id: string): Promise<AssetInfo | undefined> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
-import { SelectableValue } from '@grafana/data';
-import { DataQuery } from '@grafana/schema';
-import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData } from '@grafana/aws-sdk';
+import type { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData } from '@grafana/aws-sdk';
+import type { SelectableValue } from '@grafana/data';
+import type { DataQuery } from '@grafana/schema';
+import type { Region } from './regions';
 
 // Matches https://github.com/grafana/iot-sitewise-datasource/blob/main/pkg/models/query.go#L3
 export enum QueryType {
@@ -62,7 +63,7 @@ export enum AggregateType {
 
 export interface SitewiseQuery extends DataQuery {
   queryType: QueryType;
-  region?: string; // aws region string
+  region?: Region; // aws region string
   responseFormat?: SiteWiseResponseFormat;
 
   // QueryEditor


### PR DESCRIPTION
**What this PR does / why we need it**:

The datasource currently allows the user to select a large number of regions which do not support the AWS IoT SiteWise service.

Attempting to run a query in a region not supported by IoT SiteWise, such as the first region listed in the region drop-down, ap-east-1, leads to the following error:

```sh
failed to fetch query data: RequestError: send request failed caused by: Get "https://api.iotsitewise.ap-east-1.amazonaws.com/asset-models?maxResults=250": dial tcp: lookup api.iotsitewise.ap-east-1.amazonaws.com on 10.0.0.2:53: no such host
```

This PR removes the unsupported regions from the drop-down.

Additionally, as an improvement, the change enforces region type-safety via the `Region` type, a union of the string literal region names.