### PR TITLE
fix: disabled code editor and client cache to prepare for release

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -32,37 +32,6 @@ Multiple aggregations can be shown for a single property:
 
 ![query-editor](https://raw.githubusercontent.com/grafana/iot-sitewise-datasource/main/docs/editor2.png)
 
-### Query code editor
-
-You can run [IoT SiteWise query language](https://docs.aws.amazon.com/iot-sitewise/latest/userguide/sql.html) queries in the code editor:
-![raw-query-editor](https://raw.githubusercontent.com/grafana/iot-sitewise-datasource/main/docs/editor-switch.png)
-
-The query editor supports the following macros:
-
-* $__selectAll - Shortcut to select available fields in the current table: `select $__selectAll from raw_time_series`
-* $__timeFrom - Lower limit of the time range as a timestamp: `select $__selectAll from latest_value_time_series where event_timestamp > $__timeFrom`
-* $__timeTo - Upper limit of the time range as a timestamp: `select $__selectAll from raw_time_series where event_timestamp <= $__timeTo`
-* $__timeFilter(column) - Filter the specified field according to the time range: `select $__selectAll from raw_time_series where $__timeFilter(event_timestamp)`
-* $__autoResolution - Shortcut to the applicable aggregate resolution based on the panel interval: `select $__selectAll from precomputed_aggregates where $__timeFilter(event_timestamp) and resolution = '$__autoResolution'`
-
-#### Example queries
-
-The queries below provide a simple introduction to the [IoT SiteWise query language](https://docs.aws.amazon.com/iot-sitewise/latest/userguide/sql.html). See the linked documentation for more details.
-
-**Retrieve all raw events**
-
-```sql
-select $__selectAll from raw_time_series where $__timeFilter(event_timestamp)
-```
-
-**Retrieve asset and property name along with raw events**
-
-```sql
-select r.event_timestamp, a.asset_name, p.property_name, r.double_value
-from asset a, asset_property p, raw_time_series r
-where $__timeFilter(event_timestamp)
-```
-
 ## Alerting
 
 Standard grafana alerting is support with this plugin, however note that alert queries may not include template variables.

--- a/src/SitewiseQueryEditor.tsx
+++ b/src/SitewiseQueryEditor.tsx
@@ -3,8 +3,8 @@ import { Space } from '@grafana/ui';
 import { InlineSelect } from '@grafana/plugin-ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
-import { EditorRows, QueryEditorMode, QueryEditorModeToggle } from '@grafana/plugin-ui';
-import { SitewiseQuery, SitewiseOptions, QueryType } from 'types';
+import { EditorRows, QueryEditorMode } from '@grafana/plugin-ui';
+import { SitewiseQuery, SitewiseOptions } from 'types';
 import { DataSource } from 'SitewiseDataSource';
 import { RawQueryEditor } from 'components/query/query-editor-raw/RawQueryEditor';
 import { VisualQueryBuilder } from 'components/query/visual-query-builder/VisualQueryBuilder';
@@ -14,17 +14,20 @@ type Props = QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions>;
 
 export function SitewiseQueryEditor(props: Props) {
   const { query, onChange, onRunQuery } = props;
+
+  // Hardcoded to Builder mode til code is ready
   const editorMode = query.editorMode || QueryEditorMode.Builder;
 
-  const onEditorModeChange = (newEditorMode: QueryEditorMode) => {
-    const newQuery = { ...query };
-    if (newEditorMode === QueryEditorMode.Code) {
-      newQuery.queryType = QueryType.ExecuteQuery;
-      newQuery.clientCache = false;
-      newQuery.rawSQL = newQuery.rawSQL || props.datasource.defaultQuery;
-    }
-    onChange({ ...newQuery, editorMode: newEditorMode });
-  };
+  // Uncomment the following code when Builder mode is ready
+  // const onEditorModeChange = (newEditorMode: QueryEditorMode) => {
+  //   const newQuery = { ...query };
+  //   if (newEditorMode === QueryEditorMode.Code) {
+  //     newQuery.queryType = QueryType.ExecuteQuery;
+  //     newQuery.clientCache = false;
+  //     newQuery.rawSQL = newQuery.rawSQL || props.datasource.defaultQuery;
+  //   }
+  //   onChange({ ...newQuery, editorMode: newEditorMode });
+  // };
 
   const onRegionChange = (sel: SelectableValue<Region>) => {
     onChange({ ...query, region: sel.value });
@@ -39,7 +42,8 @@ export function SitewiseQueryEditor(props: Props) {
       <QueryEditorHeader<DataSource, SitewiseQuery, SitewiseOptions>
         {...props}
         enableRunButton
-        extraHeaderElementRight={<QueryEditorModeToggle mode={editorMode!} onChange={onEditorModeChange} />}
+        // Uncomment the following code when Builder mode is ready
+        // extraHeaderElementRight={<QueryEditorModeToggle mode={editorMode!} onChange={onEditorModeChange} />}
         extraHeaderElementLeft={
           editorMode == QueryEditorMode.Code ? (
             <InlineSelect

--- a/src/components/query/visual-query-builder/ClientCacheRow.tsx
+++ b/src/components/query/visual-query-builder/ClientCacheRow.tsx
@@ -14,7 +14,7 @@ export const ClientCacheRow = ({ clientCache, onClientCacheChange }: Props) => {
         <EditorField
           label="Client cache"
           htmlFor="clientCache"
-          tooltip="Enable to cache results in the browser that are older than 15 minutes. This will improve performance for repeated queries with relative time range."
+          tooltip="Enable to cache results in the browser that are older than 15 minutes. Note: Dashboard variable query result will not update when client cache is enabled."
         >
           <Switch id="clientCache" value={clientCache} onChange={onClientCacheChange} />
         </EditorField>

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
@@ -18,7 +18,7 @@ type Props = QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions>;
 const queryDefaults: Partial<SitewiseQuery> = {
   maxPageAggregations: 1,
   flattenL4e: true,
-  clientCache: true,
+  clientCache: false,
 };
 
 export function VisualQueryBuilder(props: Props) {

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -190,27 +190,28 @@ test.describe('Query Editor', () => {
       await panelEditPage.setVisualization('Table');
     });
 
-    test('Switch to Code Editor', async ({ page, panelEditPage, selectors }) => {
-      await page.getByRole('radio', { name: 'Code' }).click();
-      await page.waitForFunction(() => window.monaco);
-      await expect(panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container)).toBeVisible();
-    });
+    // Uncomment the following code when Builder mode is ready
+    // test('Switch to Code Editor', async ({ page, panelEditPage, selectors }) => {
+    //   await page.getByRole('radio', { name: 'Code' }).click();
+    //   await page.waitForFunction(() => window.monaco);
+    //   await expect(panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container)).toBeVisible();
+    // });
 
-    test('Displays the correct initial value', async ({ page, panelEditPage, selectors }) => {
-      await page.getByRole('radio', { name: 'Code' }).click();
-      await page.waitForFunction(() => window.monaco);
-      await expect(panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container)).toContainText(
-        'select $__selectAll from raw_time_series where $__timeFilter(event_timestamp)'
-      );
-    });
+    // test('Displays the correct initial value', async ({ page, panelEditPage, selectors }) => {
+    //   await page.getByRole('radio', { name: 'Code' }).click();
+    //   await page.waitForFunction(() => window.monaco);
+    //   await expect(panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container)).toContainText(
+    //     'select $__selectAll from raw_time_series where $__timeFilter(event_timestamp)'
+    //   );
+    // });
 
-    test('Accepts keyboard input', async ({ page, panelEditPage, selectors }) => {
-      await page.getByRole('radio', { name: 'Code' }).click();
-      await page.waitForFunction(() => window.monaco);
-      const editor = panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container);
-      await editor.click();
-      await page.keyboard.insertText('SELECT * FROM new_table');
-      await expect(editor).toContainText('SELECT * FROM new_table');
-    });
+    // test('Accepts keyboard input', async ({ page, panelEditPage, selectors }) => {
+    //   await page.getByRole('radio', { name: 'Code' }).click();
+    //   await page.waitForFunction(() => window.monaco);
+    //   const editor = panelEditPage.getByGrafanaSelector(selectors.components.CodeEditor.container);
+    //   await editor.click();
+    //   await page.keyboard.insertText('SELECT * FROM new_table');
+    //   await expect(editor).toContainText('SELECT * FROM new_table');
+    // });
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

1. SiteWise service team determined that the Code editor feature is not yet ready for release. Code editor queries result in an error when there are multiple queries sent. This PR disables Code editor feature and no users will be able to utilize it.
![Screenshot 2025-03-11 at 1 22 06 PM](https://github.com/user-attachments/assets/4c57d2a5-6e1e-4696-aeab-7c2dcdd7f50e)

1. Queries with client cache enabled do not account for variable changes in properties and variable query result will not update when client cache is enabled. This PR makes client cache disabled by default.
![Screenshot 2025-03-11 at 1 21 32 PM](https://github.com/user-attachments/assets/6b1fc8fe-9d1d-4261-b879-b993d5a31cc4)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

SiteWise service team is prioritizing the issue aforementioned.