### PR TITLE
fix: client cache switch should control the correct query

### DIFF
--- a/src/components/query/visual-query-builder/ClientCacheRow.tsx
+++ b/src/components/query/visual-query-builder/ClientCacheRow.tsx
@@ -5,18 +5,21 @@ import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/plugin-ui';
 interface Props {
   clientCache?: boolean;
   onClientCacheChange: (evt: React.SyntheticEvent<HTMLInputElement>) => void;
+  queryRefId: string;
 }
 
-export const ClientCacheRow = ({ clientCache, onClientCacheChange }: Props) => {
+export const ClientCacheRow = ({ clientCache, onClientCacheChange, queryRefId }: Props) => {
+  const cacheSwitchId = `client-cache-switch-${queryRefId}`;
+
   return (
     <EditorRow>
       <EditorFieldGroup>
         <EditorField
           label="Client cache"
-          htmlFor="clientCache"
+          htmlFor={cacheSwitchId}
           tooltip="Enable to cache results in the browser that are older than 15 minutes. Note: Dashboard variable query result will not update when client cache is enabled."
         >
-          <Switch id="clientCache" value={clientCache} onChange={onClientCacheChange} />
+          <Switch id={cacheSwitchId} value={clientCache} onChange={onClientCacheChange} />
         </EditorField>
       </EditorFieldGroup>
     </EditorRow>

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
@@ -89,7 +89,11 @@ export function VisualQueryBuilder(props: Props) {
   ) : undefined;
 
   const clientCacheRow = (
-    <ClientCacheRow clientCache={query.clientCache} onClientCacheChange={onClientCacheChange}></ClientCacheRow>
+    <ClientCacheRow
+      clientCache={query.clientCache}
+      onClientCacheChange={onClientCacheChange}
+      queryRefId={query.refId}
+    />
   );
 
   return (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

This PR removed the `id` attribute from `<Switch>` of client cache to avoid only the first `<Switch>`'s `onChange` is triggered. This fixes the issue #450  

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #450

**Special notes for your reviewer**: