### PR TITLE
fix: client cache should respect variable changes

### DIFF
--- a/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.test.ts
@@ -1,4 +1,11 @@
-import { AggregateType, QueryType, SiteWiseQuality, SiteWiseResolution, SiteWiseResponseFormat, SiteWiseTimeOrder } from 'types';
+import {
+  AggregateType,
+  QueryType,
+  SiteWiseQuality,
+  SiteWiseResolution,
+  SiteWiseResponseFormat,
+  SiteWiseTimeOrder,
+} from 'types';
 import { generateSiteWiseQueriesCacheId, generateSiteWiseRequestCacheId } from './cacheIdUtils';
 import { dateTime } from '@grafana/data';
 import { SitewiseQueriesUnion } from './types';
@@ -11,7 +18,9 @@ function createSiteWiseQuery(id: number): SitewiseQueriesUnion {
     assetId: `mock-asset-id-${id}`,
     assetIds: [`mock-asset-id-${id}`],
     propertyId: `mock-property-id-${id}`,
+    propertyIds: [`mock-property-id-${id}`],
     propertyAlias: `mock-property-alias-${id}`,
+    propertyAliases: [`mock-property-alias-${id}`],
     quality: SiteWiseQuality.ANY,
     resolution: SiteWiseResolution.Auto,
     lastObservation: true,
@@ -19,7 +28,7 @@ function createSiteWiseQuery(id: number): SitewiseQueriesUnion {
     maxPageAggregations: 1000,
     datasource: {
       type: 'grafana-iot-sitewise-datasource',
-      uid: 'mock-datasource-uid'
+      uid: 'mock-datasource-uid',
     },
     refId: `A-${id}`,
     timeOrdering: SiteWiseTimeOrder.ASCENDING,
@@ -28,8 +37,8 @@ function createSiteWiseQuery(id: number): SitewiseQueriesUnion {
     modelId: `mock-model-${id}`,
     filter: 'ALL',
     aggregates: [AggregateType.AVERAGE],
-    timeSeriesType: "DISASSOCIATED",
-    aliasPrefix: "aws/mock/disassociated"
+    timeSeriesType: 'DISASSOCIATED',
+    aliasPrefix: 'aws/mock/disassociated',
   };
 }
 
@@ -37,14 +46,14 @@ describe('generateSiteWiseQueriesCacheId()', () => {
   it('parses SiteWise Queries into cache Id', () => {
     const actualId = generateSiteWiseQueriesCacheId([createSiteWiseQuery(1), createSiteWiseQuery(2)]);
     const expectedId = JSON.stringify([
-      '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]',
-      '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]'
+      '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1",["mock-property-id-1"],"mock-property-alias-1",["mock-property-alias-1"],"ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]',
+      '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2",["mock-property-id-2"],"mock-property-alias-2",["mock-property-alias-2"],"ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]',
     ]);
 
     expect(actualId).toEqual(expectedId);
   });
 
-  it('parses SiteWise Query properties in a stable fashion (disregard of the order queries and queries\' properties are added)', () => {
+  it("parses SiteWise Query properties in a stable fashion (disregard of the order queries and queries' properties are added)", () => {
     // Reversed order of properties
     const query1: SitewiseQueriesUnion = {
       timeOrdering: SiteWiseTimeOrder.ASCENDING,
@@ -85,7 +94,7 @@ describe('generateSiteWiseQueriesCacheId()', () => {
     };
     const actualId = generateSiteWiseQueriesCacheId([query]);
     const expectedId = JSON.stringify([
-      '["ListAssets",null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]',
+      '["ListAssets",null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]',
     ]);
 
     expect(actualId).toEqual(expectedId);
@@ -103,8 +112,8 @@ describe('generateSiteWiseRequestCacheId()', () => {
         to: dateTime('2024-05-28T01:00:00Z'),
         raw: {
           from: 'now-15m',
-          to: 'now'
-        ,}
+          to: 'now',
+        },
       },
       scopedVars: {},
       targets: [createSiteWiseQuery(1), createSiteWiseQuery(2)],
@@ -115,9 +124,9 @@ describe('generateSiteWiseRequestCacheId()', () => {
     const expectedId = JSON.stringify([
       'now-15m',
       JSON.stringify([
-        '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1","mock-property-alias-1","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]',
-        '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2","mock-property-alias-2","ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]'
-      ])
+        '["PropertyValueHistory","us-west-2","table","mock-asset-id-1",["mock-asset-id-1"],"mock-property-id-1",["mock-property-id-1"],"mock-property-alias-1",["mock-property-alias-1"],"ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-1","mock-model-1","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]',
+        '["PropertyValueHistory","us-west-2","table","mock-asset-id-2",["mock-asset-id-2"],"mock-property-id-2",["mock-property-id-2"],"mock-property-alias-2",["mock-property-alias-2"],"ANY","AUTO",true,true,1000,"grafana-iot-sitewise-datasource","mock-datasource-uid","ASCENDING",true,"mock-hierarchy-2","mock-model-2","ALL",["AVERAGE"],"DISASSOCIATED","aws/mock/disassociated"]',
+      ]),
     ]);
 
     expect(generateSiteWiseRequestCacheId(request)).toEqual(expectedId);

--- a/src/RelativeRangeRequestCache/cacheIdUtils.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.ts
@@ -4,7 +4,12 @@ import { SitewiseQueriesUnion } from './types';
 export type RequestCacheId = string;
 
 export function generateSiteWiseRequestCacheId(request: DataQueryRequest<SitewiseQueriesUnion>): RequestCacheId {
-  const { targets, range: { raw: { from } } } = request;
+  const {
+    targets,
+    range: {
+      raw: { from },
+    },
+  } = request;
 
   return JSON.stringify([from, generateSiteWiseQueriesCacheId(targets)]);
 }
@@ -28,7 +33,9 @@ function generateSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId
     assetId,
     assetIds,
     propertyId,
+    propertyIds,
     propertyAlias,
+    propertyAliases,
     quality,
     resolution,
     lastObservation,
@@ -56,7 +63,9 @@ function generateSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId
     assetId,
     assetIds,
     propertyId,
+    propertyIds,
     propertyAlias,
+    propertyAliases,
     quality,
     resolution,
     lastObservation,

--- a/src/components/query/visual-query-builder/ClientCacheRow.tsx
+++ b/src/components/query/visual-query-builder/ClientCacheRow.tsx
@@ -17,7 +17,7 @@ export const ClientCacheRow = ({ clientCache, onClientCacheChange, queryRefId }:
         <EditorField
           label="Client cache"
           htmlFor={cacheSwitchId}
-          tooltip="Enable to cache results in the browser that are older than 15 minutes. Note: Dashboard variable query result will not update when client cache is enabled."
+          tooltip="Enable to cache results in the browser that are older than 15 minutes. This will improve performance for repeated queries with relative time range."
         >
           <Switch id={cacheSwitchId} value={clientCache} onChange={onClientCacheChange} />
         </EditorField>

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
@@ -18,7 +18,7 @@ type Props = QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions>;
 const queryDefaults: Partial<SitewiseQuery> = {
   maxPageAggregations: 1,
   flattenL4e: true,
-  clientCache: false,
+  clientCache: true,
 };
 
 export function VisualQueryBuilder(props: Props) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

This PR fixes issue #417 - When client cache is enabled, changes in variable is not detected by client cache. Changes is not detected because the variable is a placeholder (e.g. `${asset}`) and not the actual value before passing to the client cache. Hence, changes in the variable value does not change the placeholder and client cache considers no changes in the query.

Changes includes:
- `SitewiseDataSource` to interpolate variables before cache retrieval/storage (so the query properties are replaced by actual variable-values and not just variable-names)
- update client cache key to respect new SiteWiseQuery properties `propertyIds` and `propertyAliases` 

After the fix, the variable is respected:

https://github.com/user-attachments/assets/c5e7a5af-3215-4915-b731-bca16228a06d

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #417

**Special notes for your reviewer**: