### PR TITLE
chore: grafana instance version support warnning

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,3 +1,7 @@
+> ***Warning***
+>
+> We recommend customers to use Grafana version 10.4.0 or higher for the AWS IoT SiteWise Datasource. Grafana instances with versions prior to 10.4.0 are unable to use AWS IoT SiteWise data source versions beyond 1.25.2.
+
 # AWS IoT SiteWise Datasource
 
 This datasource supports reading data from [AWS IoT SiteWise](https://aws.amazon.com/iot-sitewise/) and showing it in a Grafana dashboard.

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -37,7 +37,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=10.3.0",
+    "grafanaDependency": ">=10.4.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:

We have incidents that customers using Grafana instances with versions prior to v10 are unable to see plugin versions beyond 1.25.2. To resolve this, we recommend that these customers upgrade their Grafana instances to version 10 or higher. This will ensure they can access the latest plugin versions and functionality.
To notify customers about the need to upgrade, we suggest adding a prominent message on the plugin page informing users that versions beyond 1.25.2 require a Grafana instance of v10 or later. This will help raise awareness and guide customers to the necessary upgrade to continue benefiting from the Grafana SiteWise plugin.

Render of the readme with the warning message.

![Screenshot 2025-03-28 at 12 37 48 PM](https://github.com/user-attachments/assets/74ddf91f-7e60-4166-a4b2-24d01012ef4c)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: