### PR TITLE
Chore: Update github workflows and add zizmor

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build plugin
         run: yarn build
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@8c65927553042c5cf701877636dd37344a8a0ce1 # v1
+        uses: grafana/plugin-actions/is-compatible@v1
         with:
           module: './src/module.ts'
           comment-pr: 'no'

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -1,11 +1,14 @@
 name: Compatibility check
 on: [push, pull_request]
-
+permissions: 
+  contents: read
 jobs:
   compatibilitycheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with: 
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -14,7 +17,7 @@ jobs:
       - name: Build plugin
         run: yarn build
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@v1
+        uses: grafana/plugin-actions/is-compatible@8c65927553042c5cf701877636dd37344a8a0ce1 # v1
         with:
           module: './src/module.ts'
           comment-pr: 'no'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,11 +63,11 @@ jobs:
           GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
-        uses: grafana/plugin-actions/wait-for-grafana@c233e9f6752186a9b256a2a451ec3067fbf712c2 # main
+        uses: grafana/plugin-actions/wait-for-grafana@main
 
       - name: Get secrets for e2e tests and set in env
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           repo_secrets: |
             AWS_ACCESS_KEY=e2e:AWS_ACCESS_KEY

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   resolve-versions:
@@ -16,12 +15,14 @@ jobs:
     steps:
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main
+        uses: grafana/plugin-actions/e2e-version@c233e9f6752186a9b256a2a451ec3067fbf712c2 # main
         with:
           version-resolver-type: version-support-policy
 
   playwright-tests:
     needs: resolve-versions
+    permissions:
+      id-token: write
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -31,7 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+        with: 
+          persist-credentials: false
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
@@ -39,7 +41,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install Mage
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
         with:
           install-only: true
 
@@ -61,16 +63,11 @@ jobs:
           GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
-        uses: nev7n/wait_for_response@v1
-        with:
-          url: 'http://localhost:3000/'
-          responseCode: 200
-          timeout: 60000
-          interval: 500
+        uses: grafana/plugin-actions/wait-for-grafana@c233e9f6752186a9b256a2a451ec3067fbf712c2 # main
 
       - name: Get secrets for e2e tests and set in env
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
         with:
           repo_secrets: |
             AWS_ACCESS_KEY=e2e:AWS_ACCESS_KEY

--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -2,6 +2,9 @@ name: Run commands when issues are labeled
 on:
   issues:
     types: [labeled, unlabeled]
+permissions: 
+  contents: read
+  issues: write
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -12,6 +15,7 @@ jobs:
           repository: 'grafana/grafana-github-actions'
           path: ./actions
           ref: main
+          persist-credentials: false
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: 'Generate token'

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,6 +1,6 @@
 name: PR automation
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - labeled
       - opened

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -6,6 +6,9 @@ on:
       - opened
 concurrency:
   group: pr-commands-${{ github.event.number }}
+permissions: 
+  contents: read
+  pull-requests: write
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -16,6 +19,7 @@ jobs:
           repository: 'grafana/grafana-github-actions'
           path: ./actions
           ref: main
+          persist-credentials: false
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: 'Generate token'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: any
+        github/*: any
+        grafana/*: any

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -90,6 +90,7 @@
     "unmarshalling",
     "assetid",
     "propid",
-    "compatibilitycheck"
+    "compatibilitycheck",
+    "zizmor"
   ]
 }

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -89,6 +89,7 @@
     "viant",
     "unmarshalling",
     "assetid",
-    "propid"
+    "propid",
+    "compatibilitycheck"
   ]
 }


### PR DESCRIPTION
As per Zizmor warnings. I also changed uses: nev7n/wait_for_response@v1 for "wait for grafana" step to the grafana action to follow what we have in other repos. if this cause e2e tests to fail, we can add the config back and see if that helps