### PR TITLE
Fixed SiteWise Query Timestamp Support in Code Editor #486

### DIFF
--- a/pkg/sitewise/api/execute_query.go
+++ b/pkg/sitewise/api/execute_query.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iotsitewise"
-
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/iot-sitewise-datasource/pkg/framer"
 	"github.com/grafana/iot-sitewise-datasource/pkg/models"
+	"github.com/grafana/iot-sitewise-datasource/pkg/util"
 )
 
 func ExecuteQuery(ctx context.Context, client iotsitewise.ExecuteQueryAPIClient, query models.ExecuteQuery) (*framer.QueryResults, error) {
-	backend.Logger.FromContext(ctx).Debug("Running ExecuteQuery", "query", query.RawSQL)
+	backend.Logger.FromContext(ctx).Debug("Running ExecuteQuery", "query", util.TimestampToDate(query.RawSQL, &query.Query.TimeRange))
 	input := &iotsitewise.ExecuteQueryInput{
 		QueryStatement: aws.String(query.RawSQL),
 		MaxResults:     aws.Int32(2000),

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,4 +13,38 @@ func TimeRangeToUnix(tr backend.TimeRange) (from *time.Time, to *time.Time) {
 	from = aws.Time(time.Unix(tr.From.Unix(), 0))
 	to = aws.Time(time.Unix(tr.To.Unix(), 0))
 	return
+}
+
+// TimestampToDate replaces epoch timestamps in rawSQL with formatted TIMESTAMP strings
+// based on the provided timeRange.
+func TimestampToDate(rawSQL string, timeRange *backend.TimeRange) string {
+	if timeRange != nil {
+		fromEpoch, toEpoch := GetEpochRange(timeRange.From, timeRange.To)
+		fromStr, toStr := GetFormattedTimeRange(timeRange.From, timeRange.To)
+		rawSQL = ReplaceEpochWithTimestamp(rawSQL, fromEpoch, fromStr)
+		rawSQL = ReplaceEpochWithTimestamp(rawSQL, toEpoch, toStr)
+	}
+	return rawSQL
+}
+
+// GetEpochRange returns the Unix epoch timestamps (in seconds)
+// for the provided 'from' and 'to' time.Time values.
+func GetEpochRange(from, to time.Time) (int64, int64) {
+	return from.Unix(), to.Unix()
+}
+
+// GetFormattedTimeRange returns the 'from' and 'to' time.Time values
+// formatted as UTC strings in the "TIMESTAMP 'YYYY-MM-DD HH:MM:SS'" format.
+func GetFormattedTimeRange(from, to time.Time) (string, string) {
+	const sqlFormat = "2006-01-02 15:04:05"
+	return from.UTC().Format(sqlFormat), to.UTC().Format(sqlFormat)
+}
+
+// ReplaceEpochWithTimestamp replaces all occurrences of the given epoch
+// timestamp (in seconds) in the provided SQL string with a formatted
+// SQL TIMESTAMP literal.
+func ReplaceEpochWithTimestamp(sql string, epoch int64, timestampStr string) string {
+	epochStr := fmt.Sprintf("%d", epoch)
+	timestampSQL := fmt.Sprintf("TIMESTAMP '%s'", timestampStr)
+	return strings.ReplaceAll(sql, epochStr, timestampSQL)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
This PR fixes the issue where the logger was outputting timestamps in an execute query in code editor, which did not comply with AWS IoT SiteWise expectations. The timestamp value has now been updated to the correct  format (e.g., `TIMESTAMP '2022-01-05 12:15:00'`) required by SiteWise for proper query execution and debugging.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes  [#486](https://github.com/grafana/iot-sitewise-datasource/issues/486)

**Special notes for your reviewer**:
- No changes were made to the actual query logic—only to the logging of timestamp values.