### PR TITLE
Chore: Migrate to Github actions + migrate to eslintv9

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,7 +34,7 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      golangci-lint-version: '2.0.2'
+      golangci-lint-version: '2.1.6'
       # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
       run-playwright: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,47 @@
+name: Plugins - CD
+run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to publish from. Can be used to deploy PRs to dev
+        default: main
+      environment:
+        description: Environment to publish to
+        required: true
+        type: choice
+        options:
+          - "dev"
+          - "ops"
+          - "prod"
+      docs-only:
+        description: Only publish docs, do not publish the plugin
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  cd:
+    name: CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      branch: ${{ github.event.inputs.branch }}
+      environment: ${{ github.event.inputs.environment }}
+      docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
+      golangci-lint-version: '2.0.2'
+      # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
+      run-playwright: false
+
+      # Scope for the plugin published to the catalog. Setting this to "grafana_cloud" will make it visible only in Grafana Cloud
+      # (and hide it for on-prem). This is required for some provisioned plugins.
+      # scopes: grafana_cloud
+
+      # Also deploy the plugin to Grafana Cloud via Argo. You also have to follow the Argo Workflows setup guide for this to work.
+      # grafana-cloud-deployment-type: provisioned
+      # argo-workflow-slack-channel: "#grafana-plugins-platform-ci"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,22 @@
+name: Plugins - CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  ci:
+    name: CI
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      golangci-lint-version: '2.0.2'
+      # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
+      run-playwright: false

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,6 +17,6 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-      golangci-lint-version: '2.0.2'
+      golangci-lint-version: '2.1.6'
       # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
       run-playwright: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,0 @@
-run:
-  skip-files:
-    - pkg/resource/caching_resource_provider.go
-    - pkg/sitewise/test_data_test.go

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   // Prettier configuration provided by Grafana scaffolding
-  ...require("./.config/.prettierrc.js")
+  ...require('./.config/.prettierrc.js'),
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,35 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import js from "@eslint/js";
-import { FlatCompat } from "@eslint/eslintrc";
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import js from '@eslint/js';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
 });
 
-export default [...compat.extends("./.config/.eslintrc"), {
+export default [
+  {
+    ignores: ['**/node_modules', '**/build', '**/dist', '**/playwright-report', '**/test-results'],
+  },
+  ...compat.extends('./.config/.eslintrc'),
+  {
     rules: {
-        "prefer-const": "warn",
+      'prefer-const': 'warn',
     },
-}];
+  },
+  {
+    rules: {
+      'deprecation/deprecation': 'off',
+    },
+  },
+  {
+    files: ['src/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      '@typescript-eslint/no-deprecated': 'warn',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "e2e": "playwright test",
     "e2e:debug": "npx playwright test --ui",
     "generate-release-notes": "PREV_TAG=$(git tag | tail -n 1) && gh api --method POST /repos/grafana/iot-sitewise-datasource/releases/generate-notes -f tag_name=v${npm_package_version} -f target_commitish=main -f previous_tag_name=${PREV_TAG} | jq -r .body",
-    "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
+    "lint": "eslint --cache .",
     "lint:fix": "yarn run lint --fix && prettier --write --list-different .",
     "server": "docker compose up --build",
     "server:dev": "DEVELOPMENT=true yarn server",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "webpack-cli": "^6.0.1",
     "webpack-livereload-plugin": "^3.0.2",
     "@stylistic/eslint-plugin-ts": "^4.2.0",
-    "@types/testing-library__jest-dom": "6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "eslint": "^9.26.0",

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -64,6 +64,5 @@ func GetExecuteQuery(dq *backend.DataQuery) (*ExecuteQuery, error) {
 	query.Query.Interval = dq.Interval
 	query.Query.TimeRange = dq.TimeRange
 	query.Query.MaxDataPoints = dq.MaxDataPoints
-	query.Query.RawSQL = query.RawSQL
 	return query, nil
 }

--- a/pkg/models/setting.go
+++ b/pkg/models/setting.go
@@ -54,18 +54,18 @@ func (s *AWSSiteWiseDataSourceSetting) Validate() error {
 	}
 
 	if s.Endpoint == "" {
-		return fmt.Errorf("Edge region requires an explicit endpoint")
+		return fmt.Errorf("edge region requires an explicit endpoint")
 	}
 	if s.Cert == "" {
-		return fmt.Errorf("Edge region requires an SSL certificate")
+		return fmt.Errorf("edge region requires an SSL certificate")
 	}
 
 	if s.EdgeAuthMode != EDGE_AUTH_MODE_DEFAULT {
 		if s.EdgeAuthUser == "" {
-			return fmt.Errorf("Missing edge auth user")
+			return fmt.Errorf("missing edge auth user")
 		}
 		if s.EdgeAuthPass == "" {
-			return fmt.Errorf("Missing edge auth password")
+			return fmt.Errorf("missing edge auth password")
 		}
 	}
 

--- a/pkg/resource/caching_resource_provider.go
+++ b/pkg/resource/caching_resource_provider.go
@@ -1,3 +1,4 @@
+// nolint
 package resource
 
 import (

--- a/pkg/server/last-observation.go
+++ b/pkg/server/last-observation.go
@@ -76,14 +76,16 @@ func (s *Server) lastObservation(h handler) handler {
 
 func (s *Server) lastValueQuery(ctx context.Context, query backend.DataQuery, timeOrdering iotsitewisetypes.TimeOrdering) (backend.DataResponse, error) {
 	query.MaxDataPoints = 1
-	if timeOrdering == iotsitewisetypes.TimeOrderingDescending {
+	switch timeOrdering {
+	case iotsitewisetypes.TimeOrderingDescending:
 		query.TimeRange.To = query.TimeRange.From.Add(-1 * time.Second)
 		query.TimeRange.From = query.TimeRange.From.Add(-8760 * time.Hour) // 1 year ago
-	} else if timeOrdering == iotsitewisetypes.TimeOrderingAscending {
+
+	case iotsitewisetypes.TimeOrderingAscending:
 		query.TimeRange.From = query.TimeRange.To.Add(time.Second)
 		query.TimeRange.To = time.Now()
-	}
 
+	}
 	assetQuery, err := models.GetAssetPropertyValueQuery(&query)
 	if err != nil {
 		return backend.DataResponse{}, err

--- a/pkg/sitewise/api/list_associated_assets.go
+++ b/pkg/sitewise/api/list_associated_assets.go
@@ -21,7 +21,7 @@ func ListAssociatedAssets(ctx context.Context, client client.SitewiseAPIClient, 
 
 	seenAssetIds := make(map[string]bool)
 
-	for _, assetId := range query.BaseQuery.AssetIds {
+	for _, assetId := range query.AssetIds {
 		assetIdPtr := aws.String(assetId)
 
 		// Recursively load children

--- a/pkg/sitewise/api/test_data_test.go
+++ b/pkg/sitewise/api/test_data_test.go
@@ -1,3 +1,4 @@
+// nolint
 package api
 
 import (

--- a/pkg/sitewise/auth.go
+++ b/pkg/sitewise/auth.go
@@ -115,10 +115,10 @@ func (a *EdgeAuthenticator) Authenticate() error {
 
 	client := &http.Client{Transport: tr, Timeout: time.Second * 5}
 
-	u, err := url.Parse(a.Settings.AWSDatasourceSettings.Endpoint)
+	u, err := url.Parse(a.Settings.Endpoint)
 	if err != nil {
-		log.DefaultLogger.Error("error parsing edge endpoint url.", "endpoint url:", a.Settings.AWSDatasourceSettings.Endpoint)
-		return fmt.Errorf("cannot parse edge endpoint url. url: %v", a.Settings.AWSDatasourceSettings.Endpoint)
+		log.DefaultLogger.Error("error parsing edge endpoint url.", "endpoint url:", a.Settings.Endpoint)
+		return fmt.Errorf("cannot parse edge endpoint url. url: %v", a.Settings.Endpoint)
 	}
 	u.Path = path.Join(u.Path, "authenticate")
 	authEndpoint := u.String()

--- a/pkg/sitewise/datasource.go
+++ b/pkg/sitewise/datasource.go
@@ -219,13 +219,13 @@ func (ds *Datasource) HandleGetAssetPropertyAggregateQuery(ctx context.Context, 
 }
 
 func (ds *Datasource) HandleGetAssetPropertyValueQuery(ctx context.Context, query *models.AssetPropertyValueQuery) (data.Frames, error) {
-	sw, err := ds.getClient(ctx, query.BaseQuery.AwsRegion)
+	sw, err := ds.getClient(ctx, query.AwsRegion)
 	if err != nil {
 		return nil, err
 	}
 
 	// Batch API is not available at the edge
-	if query.BaseQuery.AwsRegion == EDGE_REGION {
+	if query.AwsRegion == EDGE_REGION {
 		modifiedQuery, fr, err := api.GetAssetPropertyValue(ctx, sw, *query)
 		if err != nil {
 			return nil, err

--- a/pkg/sitewise/datasource.go
+++ b/pkg/sitewise/datasource.go
@@ -159,7 +159,7 @@ func (ds *Datasource) HealthCheck(ctx context.Context, req *backend.CheckHealthR
 }
 
 func (ds *Datasource) HandleInterpolatedPropertyValueQuery(ctx context.Context, _ *backend.QueryDataRequest, query *models.AssetPropertyValueQuery) (data.Frames, error) {
-	sw, err := ds.getClient(ctx, query.BaseQuery.AwsRegion)
+	sw, err := ds.getClient(ctx, query.AwsRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -171,13 +171,13 @@ func (ds *Datasource) HandleInterpolatedPropertyValueQuery(ctx context.Context, 
 }
 
 func (ds *Datasource) HandleGetAssetPropertyValueHistoryQuery(ctx context.Context, query *models.AssetPropertyValueQuery) (data.Frames, error) {
-	sw, err := ds.getClient(ctx, query.BaseQuery.AwsRegion)
+	sw, err := ds.getClient(ctx, query.AwsRegion)
 	if err != nil {
 		return nil, err
 	}
 
 	// Batch API is not available at the edge
-	if query.BaseQuery.AwsRegion == EDGE_REGION {
+	if query.AwsRegion == EDGE_REGION {
 		modifiedQuery, fr, err := api.GetAssetPropertyValues(ctx, sw, *query)
 		if err != nil {
 			return nil, err
@@ -195,13 +195,13 @@ func (ds *Datasource) HandleGetAssetPropertyValueHistoryQuery(ctx context.Contex
 }
 
 func (ds *Datasource) HandleGetAssetPropertyAggregateQuery(ctx context.Context, query *models.AssetPropertyValueQuery) (data.Frames, error) {
-	sw, err := ds.getClient(ctx, query.BaseQuery.AwsRegion)
+	sw, err := ds.getClient(ctx, query.AwsRegion)
 	if err != nil {
 		return nil, err
 	}
 
 	// Batch API is not available at the edge
-	if query.BaseQuery.AwsRegion == EDGE_REGION {
+	if query.AwsRegion == EDGE_REGION {
 		modifiedQuery, fr, err := api.GetAssetPropertyValuesForTimeRange(ctx, sw, *query)
 		if err != nil {
 			return nil, err

--- a/src/RelativeRangeRequestCache/cacheIdUtils.ts
+++ b/src/RelativeRangeRequestCache/cacheIdUtils.ts
@@ -26,6 +26,7 @@ export function generateSiteWiseQueriesCacheId(queries: SitewiseQueriesUnion[]):
  * Parse query to cache id.
  */
 function generateSiteWiseQueryCacheId(query: SitewiseQueriesUnion): QueryCacheId {
+  /* eslint-disable @typescript-eslint/no-deprecated */
   const {
     queryType,
     region,

--- a/src/SiteWiseQueryPaginator.test.ts
+++ b/src/SiteWiseQueryPaginator.test.ts
@@ -3,6 +3,7 @@ import { DataQueryRequest, DataQueryResponse, LoadingState, dateTime } from '@gr
 import { SitewiseQueryPaginator } from 'SiteWiseQueryPaginator';
 import { QueryType, SitewiseNextQuery, SitewiseQuery } from 'types';
 import { first, last } from 'rxjs/operators';
+import { firstValueFrom, lastValueFrom } from 'rxjs';
 
 // Request for SiteWise data
 const dataQueryRequest: DataQueryRequest<SitewiseQuery> = {
@@ -16,8 +17,8 @@ const dataQueryRequest: DataQueryRequest<SitewiseQuery> = {
     to: dateTime('2024-05-28T21:29:49.659Z'),
     raw: {
       from: 'now-30m',
-      to: 'now'
-    }
+      to: 'now',
+    },
   },
   interval: '2s',
   intervalMs: 2000,
@@ -25,34 +26,32 @@ const dataQueryRequest: DataQueryRequest<SitewiseQuery> = {
     {
       datasource: {
         type: 'grafana-iot-sitewise-datasource',
-        uid: 's0PWceLIz'
+        uid: 's0PWceLIz',
       },
-      assetIds: [
-        '0af4b18d-8c44-4944-8f59-9001b8824362'
-      ],
+      assetIds: ['0af4b18d-8c44-4944-8f59-9001b8824362'],
       flattenL4e: true,
       maxPageAggregations: 1,
       propertyId: '3e44a93c-eb71-4dfd-8aec-bb825cfdf7dd',
       queryType: QueryType.PropertyValue,
-      refId: 'A'
-    }
+      refId: 'A',
+    },
   ],
   maxDataPoints: 711,
   scopedVars: {
     __interval: {
       text: '2s',
-      value: '2s'
+      value: '2s',
     },
     __interval_ms: {
       text: '2000',
-      value: 2000
-    }
+      value: 2000,
+    },
   },
   startTime: 1716931789659,
   rangeRaw: {
     from: 'now-30m',
-    to: 'now'
-  }
+    to: 'now',
+  },
 };
 
 // Response with SiteWise data
@@ -66,43 +65,37 @@ const dataQueryResponse: DataQueryResponse = {
           name: 'time',
           type: 'time',
           typeInfo: {
-            frame: 'time.Time'
+            frame: 'time.Time',
           },
           config: {},
-          values: [
-            1716931550000
-          ],
-          entities: {}
+          values: [1716931550000],
+          entities: {},
         },
         {
           name: 'RotationsPerSecond',
           type: 'number',
           typeInfo: {
-            frame: 'float64'
+            frame: 'float64',
           },
           config: {
-            unit: 'RPS'
+            unit: 'RPS',
           },
-          values: [
-            0.45253960150485795
-          ],
-          entities: {}
+          values: [0.45253960150485795],
+          entities: {},
         },
         {
           name: 'quality',
           type: 'string',
           typeInfo: {
-            frame: 'string'
+            frame: 'string',
           },
           config: {},
-          values: [
-            'GOOD'
-          ],
-          entities: {}
-        }
+          values: ['GOOD'],
+          entities: {},
+        },
       ],
-      length: 1
-    }
+      length: 1,
+    },
   ],
   state: LoadingState.Done,
 };
@@ -119,8 +112,8 @@ const dataQueryRequestPaginating: DataQueryRequest<SitewiseNextQuery> = {
     to: dateTime('2024-05-28T21:29:49.659Z'),
     raw: {
       from: 'now-30m',
-      to: 'now'
-    }
+      to: 'now',
+    },
   },
   interval: '2s',
   intervalMs: 2000,
@@ -128,11 +121,9 @@ const dataQueryRequestPaginating: DataQueryRequest<SitewiseNextQuery> = {
     {
       datasource: {
         type: 'grafana-iot-sitewise-datasource',
-        uid: 's0PWceLIz'
+        uid: 's0PWceLIz',
       },
-      assetIds: [
-        '0af4b18d-8c44-4944-8f59-9001b8824362'
-      ],
+      assetIds: ['0af4b18d-8c44-4944-8f59-9001b8824362'],
       flattenL4e: true,
       maxPageAggregations: 1,
       propertyId: '3e44a93c-eb71-4dfd-8aec-bb825cfdf7dd',
@@ -140,24 +131,24 @@ const dataQueryRequestPaginating: DataQueryRequest<SitewiseNextQuery> = {
       refId: 'A',
       nextToken: 'mock-next-token-value',
       nextTokens: {},
-    }
+    },
   ],
   maxDataPoints: 711,
   scopedVars: {
     __interval: {
       text: '2s',
-      value: '2s'
+      value: '2s',
     },
     __interval_ms: {
       text: '2000',
-      value: 2000
-    }
+      value: 2000,
+    },
   },
   startTime: 1716931789659,
   rangeRaw: {
     from: 'now-30m',
-    to: 'now'
-  }
+    to: 'now',
+  },
 };
 
 // Response with SiteWise next token
@@ -171,49 +162,43 @@ const dataQueryResponsePaginating: DataQueryResponse = {
           name: 'time',
           type: 'time',
           typeInfo: {
-            frame: 'time.Time'
+            frame: 'time.Time',
           },
           config: {},
-          values: [
-            1716931549000
-          ],
-          entities: {}
+          values: [1716931549000],
+          entities: {},
         },
         {
           name: 'RotationsPerSecond',
           type: 'number',
           typeInfo: {
-            frame: 'float64'
+            frame: 'float64',
           },
           config: {
-            unit: 'RPS'
+            unit: 'RPS',
           },
-          values: [
-            1
-          ],
-          entities: {}
+          values: [1],
+          entities: {},
         },
         {
           name: 'quality',
           type: 'string',
           typeInfo: {
-            frame: 'string'
+            frame: 'string',
           },
           config: {},
-          values: [
-            'GOOD'
-          ],
-          entities: {}
-        }
+          values: ['GOOD'],
+          entities: {},
+        },
       ],
       length: 1,
       meta: {
         custom: {
           nextToken: 'mock-next-token-value',
-          resolution: 'RAW'
-        }
+          resolution: 'RAW',
+        },
       },
-    }
+    },
   ],
   state: LoadingState.Done,
 };
@@ -229,46 +214,37 @@ const dataQueryResponseCombined: DataQueryResponse = {
           name: 'time',
           type: 'time',
           typeInfo: {
-            frame: 'time.Time'
+            frame: 'time.Time',
           },
           config: {},
-          values: [
-            1716931549000,
-            1716931550000
-          ],
-          entities: {}
+          values: [1716931549000, 1716931550000],
+          entities: {},
         },
         {
           name: 'RotationsPerSecond',
           type: 'number',
           typeInfo: {
-            frame: 'float64'
+            frame: 'float64',
           },
           config: {
-            unit: 'RPS'
+            unit: 'RPS',
           },
-          values: [
-            1,
-            0.45253960150485795
-          ],
-          entities: {}
+          values: [1, 0.45253960150485795],
+          entities: {},
         },
         {
           name: 'quality',
           type: 'string',
           typeInfo: {
-            frame: 'string'
+            frame: 'string',
           },
           config: {},
-          values: [
-            'GOOD',
-            'GOOD'
-          ],
-          entities: {}
-        }
+          values: ['GOOD', 'GOOD'],
+          entities: {},
+        },
       ],
-      length: 2
-    }
+      length: 2,
+    },
   ],
   state: LoadingState.Done,
 };
@@ -284,10 +260,10 @@ describe('SitewiseQueryPaginator', () => {
         queryFn,
       }).toObservable();
 
-      const firstResponse = queryObservable.pipe(first()).toPromise();
+      const firstResponse = firstValueFrom(queryObservable);
       expect(firstResponse).resolves.toMatchObject(dataQueryResponse);
 
-      const lastResponse = queryObservable.pipe(last()).toPromise();
+      const lastResponse = lastValueFrom(queryObservable.pipe(last()));
       expect(lastResponse).resolves.toMatchObject(dataQueryResponse);
 
       await lastResponse;
@@ -306,43 +282,37 @@ describe('SitewiseQueryPaginator', () => {
                 name: 'time',
                 type: 'time',
                 typeInfo: {
-                  frame: 'time.Time'
+                  frame: 'time.Time',
                 },
                 config: {},
-                values: [
-                  1716931540000
-                ],
-                entities: {}
+                values: [1716931540000],
+                entities: {},
               },
               {
                 name: 'RotationsPerSecond',
                 type: 'number',
                 typeInfo: {
-                  frame: 'float64'
+                  frame: 'float64',
                 },
                 config: {
-                  unit: 'RPS'
+                  unit: 'RPS',
                 },
-                values: [
-                  1
-                ],
-                entities: {}
+                values: [1],
+                entities: {},
               },
               {
                 name: 'quality',
                 type: 'string',
                 typeInfo: {
-                  frame: 'string'
+                  frame: 'string',
                 },
                 config: {},
-                values: [
-                  'GOOD'
-                ],
-                entities: {}
-              }
+                values: ['GOOD'],
+                entities: {},
+              },
             ],
-            length: 1
-          }
+            length: 1,
+          },
         ],
         state: LoadingState.Done,
       };
@@ -357,43 +327,37 @@ describe('SitewiseQueryPaginator', () => {
                 name: 'time',
                 type: 'time',
                 typeInfo: {
-                  frame: 'time.Time'
+                  frame: 'time.Time',
                 },
                 config: {},
-                values: [
-                  1716931560000
-                ],
-                entities: {}
+                values: [1716931560000],
+                entities: {},
               },
               {
                 name: 'RotationsPerSecond',
                 type: 'number',
                 typeInfo: {
-                  frame: 'float64'
+                  frame: 'float64',
                 },
                 config: {
-                  unit: 'RPS'
+                  unit: 'RPS',
                 },
-                values: [
-                  3
-                ],
-                entities: {}
+                values: [3],
+                entities: {},
               },
               {
                 name: 'quality',
                 type: 'string',
                 typeInfo: {
-                  frame: 'string'
+                  frame: 'string',
                 },
                 config: {},
-                values: [
-                  'GOOD'
-                ],
-                entities: {}
-              }
+                values: ['GOOD'],
+                entities: {},
+              },
             ],
-            length: 1
-          }
+            length: 1,
+          },
         ],
         state: LoadingState.Done,
       };
@@ -408,49 +372,37 @@ describe('SitewiseQueryPaginator', () => {
                 name: 'time',
                 type: 'time',
                 typeInfo: {
-                  frame: 'time.Time'
+                  frame: 'time.Time',
                 },
                 config: {},
-                values: [
-                  1716931540000,
-                  1716931550000,
-                  1716931560000
-                ],
-                entities: {}
+                values: [1716931540000, 1716931550000, 1716931560000],
+                entities: {},
               },
               {
                 name: 'RotationsPerSecond',
                 type: 'number',
                 typeInfo: {
-                  frame: 'float64'
+                  frame: 'float64',
                 },
                 config: {
-                  unit: 'RPS'
+                  unit: 'RPS',
                 },
-                values: [
-                  1,
-                  0.45253960150485795,
-                  3,
-                ],
-                entities: {}
+                values: [1, 0.45253960150485795, 3],
+                entities: {},
               },
               {
                 name: 'quality',
                 type: 'string',
                 typeInfo: {
-                  frame: 'string'
+                  frame: 'string',
                 },
                 config: {},
-                values: [
-                  'GOOD',
-                  'GOOD',
-                  'GOOD',
-                ],
-                entities: {}
-              }
+                values: ['GOOD', 'GOOD', 'GOOD'],
+                entities: {},
+              },
             ],
-            length: 3
-          }
+            length: 3,
+          },
         ],
         state: LoadingState.Done,
       };
@@ -467,7 +419,7 @@ describe('SitewiseQueryPaginator', () => {
         queryFn,
       }).toObservable();
 
-      const lastResponse = queryObservable.pipe(last()).toPromise();
+      const lastResponse = lastValueFrom(queryObservable);
       expect(lastResponse).resolves.toMatchObject(expectedResponse);
 
       await lastResponse;
@@ -477,7 +429,8 @@ describe('SitewiseQueryPaginator', () => {
 
     it('handles more than 1 page request', async () => {
       const request = dataQueryRequest;
-      const queryFn = jest.fn()
+      const queryFn = jest
+        .fn()
         .mockResolvedValueOnce(dataQueryResponsePaginating)
         .mockResolvedValueOnce(dataQueryResponse);
 
@@ -486,13 +439,13 @@ describe('SitewiseQueryPaginator', () => {
         queryFn,
       }).toObservable();
 
-      const firstResponse = queryObservable.pipe(first()).toPromise();
+      const firstResponse = firstValueFrom(queryObservable);
       expect(firstResponse).resolves.toMatchObject({
         ...dataQueryResponsePaginating,
         state: LoadingState.Streaming,
       });
 
-      const lastResponse = queryObservable.pipe(last()).toPromise();
+      const lastResponse = lastValueFrom(queryObservable);
       expect(lastResponse).resolves.toMatchObject(dataQueryResponseCombined);
 
       await lastResponse;
@@ -503,7 +456,8 @@ describe('SitewiseQueryPaginator', () => {
 
     it('handles error state response and terminate pagination', async () => {
       const request = dataQueryRequest;
-      const queryFn = jest.fn()
+      const queryFn = jest
+        .fn()
         .mockResolvedValueOnce({
           ...dataQueryResponsePaginating,
           state: LoadingState.Error,
@@ -515,13 +469,13 @@ describe('SitewiseQueryPaginator', () => {
         queryFn,
       }).toObservable();
 
-      const firstResponse = queryObservable.pipe(first()).toPromise();
+      const firstResponse = firstValueFrom(queryObservable);
       expect(firstResponse).resolves.toMatchObject({
         ...dataQueryResponsePaginating,
         state: LoadingState.Error,
       });
 
-      const lastResponse = queryObservable.pipe(last()).toPromise();
+      const lastResponse = lastValueFrom(queryObservable);
       expect(lastResponse).resolves.toMatchObject({
         ...dataQueryResponsePaginating,
         state: LoadingState.Error,

--- a/src/SiteWiseQueryPaginator.test.ts
+++ b/src/SiteWiseQueryPaginator.test.ts
@@ -2,7 +2,6 @@ import { DataQueryRequest, DataQueryResponse, LoadingState, dateTime } from '@gr
 
 import { SitewiseQueryPaginator } from 'SiteWiseQueryPaginator';
 import { QueryType, SitewiseNextQuery, SitewiseQuery } from 'types';
-import { first, last } from 'rxjs/operators';
 import { firstValueFrom, lastValueFrom } from 'rxjs';
 
 // Request for SiteWise data
@@ -263,7 +262,7 @@ describe('SitewiseQueryPaginator', () => {
       const firstResponse = firstValueFrom(queryObservable);
       expect(firstResponse).resolves.toMatchObject(dataQueryResponse);
 
-      const lastResponse = lastValueFrom(queryObservable.pipe(last()));
+      const lastResponse = lastValueFrom(queryObservable);
       expect(lastResponse).resolves.toMatchObject(dataQueryResponse);
 
       await lastResponse;

--- a/src/SitewiseDataSource.ts
+++ b/src/SitewiseDataSource.ts
@@ -11,7 +11,7 @@ import {
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { SitewiseCache } from 'sitewiseCache';
 import { isListAssetsQuery, isPropertyQueryType, SitewiseOptions, SitewiseQuery, SiteWiseResolution } from './types';
-import { Observable } from 'rxjs';
+import { lastValueFrom, Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { frameToMetricFindValues } from 'utils';
 import { applyVariableForList, SitewiseVariableSupport } from 'variables';
@@ -72,7 +72,7 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
     let res: DataQueryResponse | undefined;
 
     try {
-      res = await this.query(request).toPromise();
+      res = await lastValueFrom(this.query(request));
     } catch (err) {
       return Promise.reject(err);
     }
@@ -87,6 +87,7 @@ export class DataSource extends DataSourceWithBackend<SitewiseQuery, SitewiseOpt
    * Do not execute queries that do not exist yet
    */
   filterQuery(query: SitewiseQuery): boolean {
+    /* eslint-disable @typescript-eslint/no-deprecated */
     if (!query.queryType) {
       return false; // skip the query
     }

--- a/src/SitewiseQueryEditor.tsx
+++ b/src/SitewiseQueryEditor.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Space } from '@grafana/ui';
-import { InlineSelect } from '@grafana/plugin-ui';
+import { InlineSelect, EditorRows, QueryEditorMode } from '@grafana/plugin-ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
-import { EditorRows, QueryEditorMode } from '@grafana/plugin-ui';
 import { SitewiseQuery, SitewiseOptions } from 'types';
 import { DataSource } from 'SitewiseDataSource';
 import { RawQueryEditor } from 'components/query/query-editor-raw/RawQueryEditor';
@@ -45,7 +44,7 @@ export function SitewiseQueryEditor(props: Props) {
         // Uncomment the following code when Builder mode is ready
         // extraHeaderElementRight={<QueryEditorModeToggle mode={editorMode!} onChange={onEditorModeChange} />}
         extraHeaderElementLeft={
-          editorMode == QueryEditorMode.Code ? (
+          editorMode === QueryEditorMode.Code ? (
             <InlineSelect
               label="AWS Region"
               options={regionOptions}

--- a/src/common/useOptionsWithVariables.ts
+++ b/src/common/useOptionsWithVariables.ts
@@ -9,9 +9,10 @@ export const useOptionsWithVariables = ({
   options,
 }: {
   current?: string;
-  options: SelectableValue<string>[];
+  options: Array<SelectableValue<string>>;
 }) => {
   const variableOptions = getVariableOptions({ keepVarSyntax: true });
   const variables = getTemplateSrv().getVariables();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   return useMemo(() => getSelectionInfo(current, options, variableOptions), [current, variables, options]);
 };

--- a/src/components/query/visual-query-builder/ListTimeSeriesQueryEditor.tsx
+++ b/src/components/query/visual-query-builder/ListTimeSeriesQueryEditor.tsx
@@ -98,6 +98,7 @@ export const ListTimeSeriesQueryEditorFunction = (props: Props) => {
               'The ID of the asset in which the asset property was created. This can be either the actual ID in UUID format, or else externalId: followed by the external ID, if it has one'
             }
           >
+            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
             <Input id="assetId" value={query.assetId} onChange={onAssetIdChange} placeholder="Optional: asset id" />
           </EditorField>
         )}

--- a/src/components/query/visual-query-builder/PropertyQueryEditor.tsx
+++ b/src/components/query/visual-query-builder/PropertyQueryEditor.tsx
@@ -31,13 +31,13 @@ export const PropertyQueryEditor = ({ query, datasource, onChange }: SitewiseQue
   const [assetId, setAssetId] = useState<string | undefined>(query.assetIds?.[0]);
   const [asset, setAsset] = useState<AssetInfo | undefined>(undefined);
   const [assets, setAssets] = useState<Array<SelectableValue<string>>>([]);
-  const [assetProperties, setAssetProperties] = useState<SelectableValue<string>[]>([]);
-  const [propertyAliases, setPropertyAliases] = useState<SelectableValue<string>[]>([]);
+  const [assetProperties, setAssetProperties] = useState<Array<SelectableValue<string>>>([]);
+  const [propertyAliases, setPropertyAliases] = useState<Array<SelectableValue<string>>>([]);
 
   const cache = useMemo(() => datasource.getCache(query.region), [datasource, query.region]);
 
   const onAliasChange = useCallback(
-    (sel: SelectableValue<string> | SelectableValue<string>[]) => {
+    (sel: SelectableValue<string> | Array<SelectableValue<string>>) => {
       const propertyAliases: Set<string> = new Set();
       if (Array.isArray(sel)) {
         sel.forEach((s) => {
@@ -55,7 +55,7 @@ export const PropertyQueryEditor = ({ query, datasource, onChange }: SitewiseQue
   );
 
   const onAssetChange = useCallback(
-    (sel: SelectableValue<string> | SelectableValue<string>[]) => {
+    (sel: SelectableValue<string> | Array<SelectableValue<string>>) => {
       const assetIds: Set<string> = new Set();
       if (Array.isArray(sel)) {
         sel.forEach((s) => {
@@ -78,7 +78,7 @@ export const PropertyQueryEditor = ({ query, datasource, onChange }: SitewiseQue
   );
 
   const onPropertyChange = useCallback(
-    (sel: SelectableValue<string> | SelectableValue<string>[]) => {
+    (sel: SelectableValue<string> | Array<SelectableValue<string>>) => {
       const propertyIds: Set<string> = new Set();
       if (Array.isArray(sel)) {
         sel.forEach((s) => {
@@ -254,6 +254,7 @@ export const PropertyQueryEditor = ({ query, datasource, onChange }: SitewiseQue
     ])
       .catch(console.error)
       .finally(() => setIsLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
   let selectedPropertyAliases = propertyAliases.filter(
@@ -455,8 +456,8 @@ export const PropertyQueryEditor = ({ query, datasource, onChange }: SitewiseQue
 
 const AssetTooltip = () => (
   <div>
-    Set the asset ID. It can be either the actual ID in UUID format, or else "externalId:" followed by the external ID,
-    if it has one.
+    Set the asset ID. It can be either the actual ID in UUID format, or else &quot;externalId:&quot; followed by the
+    external ID, if it has one.
     <LinkButton
       href="https://docs.aws.amazon.com/iot-sitewise/latest/userguide/object-ids.html#external-ids"
       target="_blank"

--- a/src/components/query/visual-query-builder/QualityAndOrderRow.tsx
+++ b/src/components/query/visual-query-builder/QualityAndOrderRow.tsx
@@ -16,17 +16,17 @@ const QUALITY_OPTIONS = [
   { value: SiteWiseQuality.GOOD, label: 'GOOD' },
   { value: SiteWiseQuality.BAD, label: 'BAD' },
   { value: SiteWiseQuality.UNCERTAIN, label: 'UNCERTAIN' },
-] satisfies SelectableValue<SiteWiseQuality>[];
+] satisfies Array<SelectableValue<SiteWiseQuality>>;
 
 const ORDERING_OPTIONS = [
   { value: SiteWiseTimeOrder.ASCENDING, label: 'ASCENDING' },
   { value: SiteWiseTimeOrder.DESCENDING, label: 'DESCENDING' },
-] satisfies SelectableValue<SiteWiseTimeOrder>[];
+] satisfies Array<SelectableValue<SiteWiseTimeOrder>>;
 
 export const FORMAT_OPTIONS = [
   { label: 'Table', value: SiteWiseResponseFormat.Table },
   { label: 'Time series', value: SiteWiseResponseFormat.TimeSeries },
-] satisfies SelectableValue<SiteWiseResponseFormat>[];
+] satisfies Array<SelectableValue<SiteWiseResponseFormat>>;
 
 export const QualityAndOrderRow = ({ onChange, query }: SitewiseQueryEditorProps) => {
   const onQualityChange = useCallback(

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.test.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.test.tsx
@@ -44,8 +44,11 @@ jest.mock('@grafana/runtime', () => ({
     replace: (v: string) => v,
   }),
 }));
+const mockDatasource = new DataSource(instanceSettings);
+mockDatasource.runQuery = jest.fn().mockReturnValue(of({ data: [] }));
+
 const defaultProps: QueryEditorProps<DataSource, SitewiseQuery, SitewiseOptions> = {
-  datasource: new DataSource(instanceSettings),
+  datasource: mockDatasource,
   query: { refId: 'A', queryType: QueryType.DescribeAsset },
   onRunQuery: jest.fn(),
   onChange: jest.fn(),

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
@@ -31,6 +31,7 @@ export function VisualQueryBuilder(props: Props) {
     if (query !== migratedQuery) {
       props.onChange(migratedQuery);
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated, react-hooks/exhaustive-deps
   }, [query.assetId, query.propertyId, query.propertyAlias]);
 
   const defaultRegion: SelectableValue<Region> = {

--- a/src/migrations/migrateQuery.ts
+++ b/src/migrations/migrateQuery.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-deprecated */
+
 import { SitewiseQuery } from '../types';
 
 const migrateAssetProperty = (query: SitewiseQuery): SitewiseQuery => {

--- a/src/queryInfo.ts
+++ b/src/queryInfo.ts
@@ -122,10 +122,10 @@ export function getDefaultAggregate(): AggregateType {
   return AggregateType.COUNT;
 }
 
-export function areAssetsFromSameModel(assets?: (AssetInfo | undefined)[]): boolean {
-  if (!assets || assets.length == 0) {
+export function areAssetsFromSameModel(assets?: Array<AssetInfo | undefined>): boolean {
+  if (!assets || assets.length === 0) {
     return true;
   }
   const assetModelId = assets[0]?.model_id;
-  return assets.every((assetInfo) => assetInfo?.model_id == assetModelId);
+  return assets.every((assetInfo) => assetInfo?.model_id === assetModelId);
 }

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -30,7 +30,7 @@ export type Region = (typeof supportedRegions)[number] | DefaultRegion;
 export const regionOptions = supportedRegions.map((v) => ({
   value: v,
   label: v,
-})) satisfies SelectableValue<Region>[];
+})) satisfies Array<SelectableValue<Region>>;
 
 export const isSupportedRegion = (region: Region | string | unknown): region is Region =>
   Boolean(supportedRegions.find((supportedRegion) => supportedRegion === region));

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -8,7 +8,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { useEffect, useState } from 'react';
 import { type Region } from './regions';
 import { getSelectableTemplateVariables } from 'variables';
-import { firstValueFrom, lastValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 
 /**
  * Keep a different cache for each region

--- a/src/sitewiseCache.ts
+++ b/src/sitewiseCache.ts
@@ -51,7 +51,8 @@ export class SitewiseCache {
                 return info;
               }
             }
-            throw 'asset not found';
+            console.log('Asset not found');
+            return undefined;
           })
         )
     );
@@ -92,8 +93,8 @@ export class SitewiseCache {
 
               return assetProperties;
             }
-
-            throw 'asset properties not found';
+            console.log('No asset properties found for asset', assetId);
+            return undefined;
           })
         )
     );
@@ -117,7 +118,8 @@ export class SitewiseCache {
               this.models = new DataFrameView<AssetModelSummary>(res.data[0]);
               return this.models;
             }
-            throw 'no models found';
+            console.log('No models found');
+            return undefined;
           })
         )
     );
@@ -152,7 +154,8 @@ export class SitewiseCache {
             this.topLevelAssets = new DataFrameView<AssetSummary>(res.data[0]);
             return this.topLevelAssets;
           }
-          throw 'no assets found';
+          console.log('No assets found for model', modelId);
+          return undefined;
         })
       )
     );
@@ -173,7 +176,8 @@ export class SitewiseCache {
           if (res.data.length) {
             return new DataFrameView<AssetSummary>(res.data[0]);
           } else {
-            throw 'no asset hierarchy found';
+            console.log('No associated assets found for asset', assetId);
+            return undefined;
           }
         })
       )
@@ -197,7 +201,8 @@ export class SitewiseCache {
             this.topLevelAssets = new DataFrameView<AssetSummary>(res.data[0]);
             return this.topLevelAssets;
           }
-          throw 'no assets found';
+          console.log('No top level assets found');
+          return undefined;
         })
       )
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,7 +2240,7 @@
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
-"@testing-library/jest-dom@*", "@testing-library/jest-dom@6.6.3":
+"@testing-library/jest-dom@6.6.3":
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz#26ba906cf928c0f8172e182c6fe214eb4f9f2bd2"
   integrity sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==
@@ -2532,13 +2532,6 @@
   version "6.15.1"
   resolved "https://registry.yarnpkg.com/@types/systemjs/-/systemjs-6.15.1.tgz#dae1ec2fbe66af7c6ca1a110e2c9ca6b85135eec"
   integrity sha512-MfDFIN+jRQOX1JRBrbbb72tsFJnK0n7mtLC+L2Y3t7As/vFxJiFGA/09FE+6ssFheHAibd8Q3gs959c+Sgf/9A==
-
-"@types/testing-library__jest-dom@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-6.0.0.tgz#b558b64b80a72130714be1f505c6df482d453690"
-  integrity sha512-bnreXCgus6IIadyHNlN/oI5FfX4dWgvGhOPvpr7zzCYDGAPIfvyIoAozMBINmhmsVuqV0cncejF2y5KC7ScqOg==
-  dependencies:
-    "@testing-library/jest-dom" "*"
 
 "@types/tough-cookie@*":
   version "4.0.5"


### PR DESCRIPTION
This migrates the plugin CI/CD processes to Github actions according to [this migration guide](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/020-migrating-form-drone/)

Right now the shared workflows don't have a mechanism to specify custom Vault secrets in e2e tests, so I had to disable the shared e2e workflow and keep our old e2e action. This might change in the future, but with drone sunset coming up, we don't really have a choice. More info [in this thread ](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750077883269419?thread_ts=1750072014.548489&cid=C01C4K8DETW)

+ Also had to migrate to eslintv9 so there were a lot of eslint errors and warnings
 + golangci-lint errors
+ had to change resource calls in sitewiseCache to return underfined and log an error instead of throwing an error:
```
console.log('Asset not found');
            return undefined;
```
 I don't think this new Error did anything in the UI, and it would be obvious from the lack of options that..no options were found :D It was just making the new tests fail because of the difference in behaviour between `toPromise()` (deprecated) and the new `firstValueFrom`
 