### PR TITLE
add downstream error source in failed reques

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.3.1
+
+- Chore: Add donwstream error for failed requests and unmarshalling
+
 ## 2.3.0
 
 - fix interpolated property value next token in [#506](https://github.com/grafana/iot-sitewise-datasource/pull/506)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2.3.1
 
-- Chore: Add donwstream error for failed requests and unmarshalling
+- Chore: Add downstream error for failed requests and unmarshalling
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## 2.3.1
 
-- Chore: Add downstream error for failed requests and unmarshalling
+- Add support for auto-merging dependabot updates in [#497](https://github.com/grafana/iot-sitewise-datasource/pull/497)
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/iotsitewise from 1.47.0 to 1.47.3 in [#510](https://github.com/grafana/iot-sitewise-datasource/pull/510)
+- chore(deps): bump the grafana-dependencies group with 4 updates in [#514](https://github.com/grafana/iot-sitewise-datasource/pull/514)
+- chore(deps-dev): bump prettier from 3.5.3 to 3.6.2 in [#516](https://github.com/grafana/iot-sitewise-datasource/pull/516)
+- chore(deps-dev): bump sass from 1.88.0 to 1.89.2 in [#513](https://github.com/grafana/iot-sitewise-datasource/pull/513)
+- chore(deps-dev): bump webpack from 5.99.8 to 5.100.2 in [#515](https://github.com/grafana/iot-sitewise-datasource/pull/515)
+- chore(deps): bump golang.org/x/sync from 0.15.0 to 0.16.0 in [#511](https://github.com/grafana/iot-sitewise-datasource/pull/511)
+- Run e2e tests with plugin workflows in [#519](https://github.com/grafana/iot-sitewise-datasource/pull/519)
+- Added support for grafana variables in executeQuery requests and auto suggestion grafana variables in [#501](http://github.com/grafana/iot-sitewise-datasource/pull/501)
+- Changed the time value from timestamp to date in macros in [#495](https://github.com/grafana/iot-sitewise-datasource/pull/495)
+- chore(deps-dev): bump eslint-plugin-jsdoc from 50.6.14 to 51.4.1 in [#522](https://github.com/grafana/iot-sitewise-datasource/pull/522)
+- Chore: Add downstream error for failed requests and unmarshalling in [#539](https://github.com/grafana/iot-sitewise-datasource/pull/539)
 
 ## 2.3.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-sitewise-datasource",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "View IoT Sitewise data in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,7 +39,6 @@ type QueryHandlerFunc func(context.Context, *backend.QueryDataRequest, backend.D
 func DataResponseErrorUnmarshal(err error) backend.DataResponse {
 	return backend.DataResponse{
 		Error: errors.Wrap(err, "failed to unmarshal JSON request into query"),
-		ErrorSource: backend.ErrorSourceDownstream,
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,12 +39,14 @@ type QueryHandlerFunc func(context.Context, *backend.QueryDataRequest, backend.D
 func DataResponseErrorUnmarshal(err error) backend.DataResponse {
 	return backend.DataResponse{
 		Error: errors.Wrap(err, "failed to unmarshal JSON request into query"),
+		ErrorSource: backend.ErrorSourceDownstream,
 	}
 }
 
 func DataResponseErrorRequestFailed(err error) backend.DataResponse {
 	return backend.DataResponse{
 		Error: errors.Wrap(err, "failed to fetch query data"),
+		ErrorSource: backend.ErrorSourceDownstream,
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,7 +44,7 @@ func DataResponseErrorUnmarshal(err error) backend.DataResponse {
 
 func DataResponseErrorRequestFailed(err error) backend.DataResponse {
 	return backend.DataResponse{
-		Error: errors.Wrap(err, "failed to fetch query data"),
+		Error:       errors.Wrap(err, "failed to fetch query data"),
 		ErrorSource: backend.ErrorSourceDownstream,
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md) or [src/README.md](https://github.com/grafana/iot-sitewise-datasource/blob/main/README.md).

-->

**What this PR does / why we need it**:
ErrorBudgetBurnRateTooHigh warnings in operation channel. These errors should be downstream errors, not plugin errors
https://raintank-corp.slack.com/archives/C077F654GCS/p1753890062885989
**Which issue(s) this PR fixes**:
N/A
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: