### PR TITLE
QueryData: Set default region if empty, prepare 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.3.2
+
+- QueryData: Set default region if empty in [#556](https://github.com/grafana/iot-sitewise-datasource/pull/556)
+- chore(deps): bump github.com/aws/smithy-go from 1.22.4 to 1.22.5 in [#540](https://github.com/grafana/iot-sitewise-datasource/pull/540)
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.17 to 1.29.18 in [#536](https://github.com/grafana/iot-sitewise-datasource/pull/536)
+- chore(deps-dev): bump @swc/core from 1.11.24 to 1.13.2 in [#547](https://github.com/grafana/iot-sitewise-datasource/pull/547)
+- chore(deps): bump github.com/grafana/grafana-aws-sdk from 1.0.5 to 1.1.0 in [#546](https://github.com/grafana/iot-sitewise-datasource/pull/546)
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.36.5 to 1.36.6 in [#535](https://github.com/grafana/iot-sitewise-datasource/pull/535)
+- chore(deps-dev): bump lefthook from 1.11.12 to 1.12.1 in [#532](https://github.com/grafana/iot-sitewise-datasource/pull/532)
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/iotsitewise from 1.47.3 to 1.47.4 in [#534](https://github.com/grafana/iot-sitewise-datasource/pull/534)
+- chore(deps-dev): bump @babel/core from 7.27.1 to 7.28.0 in [#528](https://github.com/grafana/iot-sitewise-datasource/pull/528)
+- Tweak dependabot schedule in [#543](https://github.com/grafana/iot-sitewise-datasource/pull/543)
+
 ## 2.3.1
 
 - Add support for auto-merging dependabot updates in [#497](https://github.com/grafana/iot-sitewise-datasource/pull/497)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-sitewise-datasource",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "View IoT Sitewise data in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	if err := datasource.Manage("sitewise-datasource", server.NewServerInstance, datasource.ManageOpts{}); err != nil {
+	if err := datasource.Manage("grafana-iot-sitewise-datasource", server.NewServerInstance, datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)
 	}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -30,12 +30,15 @@ func processQueries(ctx context.Context, req *backend.QueryDataRequest, handler 
 	}
 
 	defaultRegion := ""
+	if req.PluginContext.DataSourceInstanceSettings != nil &&
+		req.PluginContext.DataSourceInstanceSettings.JSONData != nil {
 
-	if err := json.Unmarshal(req.PluginContext.DataSourceInstanceSettings.JSONData, &datasourceJsonData); err != nil {
-		return getErrorResponse(err, "failed to unmarshal datasource JSON data")
-	}
-	if datasourceJsonData.DefaultRegion != "" {
-		defaultRegion = datasourceJsonData.DefaultRegion
+		if err := json.Unmarshal(req.PluginContext.DataSourceInstanceSettings.JSONData, &datasourceJsonData); err != nil {
+			return getErrorResponse(err, "failed to unmarshal datasource JSON data")
+		}
+		if datasourceJsonData.DefaultRegion != "" {
+			defaultRegion = datasourceJsonData.DefaultRegion
+		}
 	}
 
 	for _, q := range req.Queries {

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iotsitewise"
 
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/iot-sitewise-datasource/pkg/models"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client"
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client/mocks"
@@ -33,6 +35,11 @@ func TestHandlerExecution(t *testing.T) {
 
 	server := Server{
 		Datasource: &sitewise.Datasource{
+			Cfg: models.AWSSiteWiseDataSourceSetting{
+				AWSDatasourceSettings: awsds.AWSDatasourceSettings{
+					Region: "us-west-2",
+				},
+			},
 			GetClient: clientGetter,
 		},
 	}

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -111,70 +109,6 @@ func TestHandlerExecution(t *testing.T) {
 			}
 			mockClient := client.(*mocks.SitewiseAPIClient)
 			mockClient.AssertCalled(t, tt.handler_method, tt.called_args...)
-		})
-	}
-}
-
-func TestProcessQueries_SetsDefaultRegion(t *testing.T) {
-	ctx := context.Background()
-	defaultRegion := "us-east-2"
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "no region set",
-			input:    `{"assetIds": ["asset-1"]}`,
-			expected: defaultRegion,
-		},
-		{
-			name:     "empty region",
-			input:    `{"region": "", "assetIds": ["asset-1"]}`,
-			expected: defaultRegion,
-		},
-		{
-			name:     "default region",
-			input:    `{"region": "default", "assetIds": ["asset-1"]}`,
-			expected: defaultRegion,
-		},
-		{
-			name:     "non-empty region is preserved",
-			input:    `{"region": "eu-west-2", "assetIds": ["asset-1"]}`,
-			expected: "eu-west-2",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var capturedQuery backend.DataQuery
-			handler := func(_ context.Context, _ *backend.QueryDataRequest, q backend.DataQuery) backend.DataResponse {
-				capturedQuery = q
-				return backend.DataResponse{}
-			}
-
-			req := &backend.QueryDataRequest{
-				PluginContext: backend.PluginContext{
-					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-						JSONData: []byte(fmt.Sprintf(`{"defaultRegion": "%s"}`, defaultRegion)),
-					},
-				},
-				Queries: []backend.DataQuery{
-					{
-						RefID: "A",
-						JSON:  []byte(tt.input),
-					},
-				},
-			}
-
-			processQueries(ctx, req, handler)
-
-			var queryMap map[string]interface{}
-			err := json.Unmarshal(capturedQuery.JSON, &queryMap)
-			require.NoError(t, err)
-
-			require.Equal(t, tt.expected, queryMap["region"])
 		})
 	}
 }

--- a/pkg/server/test/server_test.go
+++ b/pkg/server/test/server_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/patrickmn/go-cache"
 
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/iot-sitewise-datasource/pkg/models"
 	"github.com/grafana/iot-sitewise-datasource/pkg/server"
 
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
@@ -50,6 +52,11 @@ func mockedDatasource(swmock *mocks.SitewiseAPIClient) server.Datasource {
 	// FIXME: GetClient isn't called
 	// FIXME: need a way to add EdgeAuthenticator
 	return &sitewise.Datasource{
+		Cfg: models.AWSSiteWiseDataSourceSetting{
+			AWSDatasourceSettings: awsds.AWSDatasourceSettings{
+				Region: "us-west-2",
+			},
+		},
 		GetClient: func(_ context.Context, _ string) (client.SitewiseAPIClient, error) {
 			return swmock, nil
 		},

--- a/pkg/sitewise/datasource.go
+++ b/pkg/sitewise/datasource.go
@@ -102,6 +102,13 @@ func (ds *Datasource) Authenticate() error {
 }
 
 func (ds *Datasource) getClient(ctx context.Context, region string) (client.SitewiseAPIClient, error) {
+	if region == "" || region == "default" {
+		if ds.cfg.Region == "" {
+			return nil, errors.New("region is not set in datasource settings")
+		}
+		region = ds.cfg.Region
+
+	}
 	if ds.GetClient != nil {
 		return ds.GetClient(ctx, region)
 	}

--- a/pkg/sitewise/datasource.go
+++ b/pkg/sitewise/datasource.go
@@ -29,7 +29,7 @@ type clientGetterFunc func(ctx context.Context, region string) (client.SitewiseA
 type invokerFunc func(ctx context.Context, sw client.SitewiseAPIClient) (framer.Framer, error)
 
 type Datasource struct {
-	cfg               models.AWSSiteWiseDataSourceSetting
+	Cfg               models.AWSSiteWiseDataSourceSetting
 	edgeAuthenticator *EdgeAuthenticator
 	proxyOptions      *proxy.Options
 	GetClient         clientGetterFunc
@@ -68,7 +68,7 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 		return nil, err
 	}
 	ds := &Datasource{
-		cfg:          cfg,
+		Cfg:          cfg,
 		proxyOptions: proxyOptions,
 	}
 
@@ -94,19 +94,19 @@ func (ds *Datasource) Authenticate() error {
 	if authInfo == nil {
 		return nil
 	}
-	ds.cfg.AuthType = awsds.AuthTypeKeys
-	ds.cfg.AccessKey = authInfo.AccessKeyId
-	ds.cfg.SecretKey = authInfo.SecretAccessKey
-	ds.cfg.SessionToken = authInfo.SessionToken
+	ds.Cfg.AuthType = awsds.AuthTypeKeys
+	ds.Cfg.AccessKey = authInfo.AccessKeyId
+	ds.Cfg.SecretKey = authInfo.SecretAccessKey
+	ds.Cfg.SessionToken = authInfo.SessionToken
 	return nil
 }
 
 func (ds *Datasource) getClient(ctx context.Context, region string) (client.SitewiseAPIClient, error) {
 	if region == "" || region == "default" {
-		if ds.cfg.Region == "" {
+		if ds.Cfg.Region == "" {
 			return nil, errors.New("region is not set in datasource settings")
 		}
-		region = ds.cfg.Region
+		region = ds.Cfg.Region
 	}
 
 	if ds.GetClient != nil {
@@ -115,21 +115,21 @@ func (ds *Datasource) getClient(ctx context.Context, region string) (client.Site
 	if err := ds.Authenticate(); err != nil {
 		return nil, err
 	}
-	httpclient, err := client.GetHTTPClient(ds.cfg)
+	httpclient, err := client.GetHTTPClient(ds.Cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	awsCfg, err := awsauth.NewConfigProvider().GetConfig(ctx, awsauth.Settings{
-		LegacyAuthType:     ds.cfg.AuthType,
-		AccessKey:          ds.cfg.AccessKey,
-		SecretKey:          ds.cfg.SecretKey,
-		SessionToken:       ds.cfg.SessionToken,
+		LegacyAuthType:     ds.Cfg.AuthType,
+		AccessKey:          ds.Cfg.AccessKey,
+		SecretKey:          ds.Cfg.SecretKey,
+		SessionToken:       ds.Cfg.SessionToken,
 		Region:             region,
-		CredentialsProfile: ds.cfg.Profile,
-		AssumeRoleARN:      ds.cfg.AssumeRoleARN,
-		Endpoint:           ds.cfg.Endpoint,
-		ExternalID:         ds.cfg.ExternalID,
+		CredentialsProfile: ds.Cfg.Profile,
+		AssumeRoleARN:      ds.Cfg.AssumeRoleARN,
+		Endpoint:           ds.Cfg.Endpoint,
+		ExternalID:         ds.Cfg.ExternalID,
 		UserAgent:          awsds.GetUserAgentString("grafana-iot-sitewise-datasource"),
 		HTTPClient:         httpclient,
 		ProxyOptions:       ds.proxyOptions,
@@ -140,7 +140,7 @@ func (ds *Datasource) getClient(ctx context.Context, region string) (client.Site
 	}
 
 	return &client.SitewiseClient{Client: iotsitewise.NewFromConfig(awsCfg, func(o *iotsitewise.Options) {
-		if ds.cfg.Region == models.EDGE_REGION {
+		if ds.Cfg.Region == models.EDGE_REGION {
 			o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
 				return stack.Initialize.Add(&disableHostPrefixMiddleware{}, middleware.Before)
 			})
@@ -164,7 +164,7 @@ func (ds *Datasource) invoke(ctx context.Context, _ *backend.QueryDataRequest, b
 
 func (ds *Datasource) HealthCheck(ctx context.Context, req *backend.CheckHealthRequest) error {
 
-	sw, err := ds.getClient(ctx, ds.cfg.Region)
+	sw, err := ds.getClient(ctx, ds.Cfg.Region)
 	if err != nil {
 		return errors.Wrap(err, "unable to load settings")
 	}

--- a/pkg/sitewise/datasource.go
+++ b/pkg/sitewise/datasource.go
@@ -107,8 +107,8 @@ func (ds *Datasource) getClient(ctx context.Context, region string) (client.Site
 			return nil, errors.New("region is not set in datasource settings")
 		}
 		region = ds.cfg.Region
-
 	}
+
 	if ds.GetClient != nil {
 		return ds.GetClient(ctx, region)
 	}

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.test.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.test.tsx
@@ -234,7 +234,7 @@ describe('VisualQueryBuilder', () => {
       }
     );
 
-    const clearButton = (await screen.findAllByRole('button', { name: 'Clear value' }))[1];
+    const clearButton = (await screen.findAllByRole('button', { name: 'Clear value' }))[0];
     expect(clearButton).toBeInTheDocument();
     await userEvent.click(clearButton);
 
@@ -261,7 +261,7 @@ describe('VisualQueryBuilder', () => {
       }
     );
 
-    const clearButton = (await screen.findAllByRole('button', { name: 'Clear value' }))[1];
+    const clearButton = (await screen.findAllByRole('button', { name: 'Clear value' }))[0];
     expect(clearButton).toBeInTheDocument();
     await userEvent.click(clearButton);
 

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
@@ -115,12 +115,12 @@ export function VisualQueryBuilder(props: Props) {
             </EditorField>
             <EditorField label="Region" width={15}>
               <Select
+                isClearable={false}
                 options={regions}
                 value={regionOptions.find((v) => v.value === query.region) || defaultRegion}
                 onChange={onRegionChange}
                 backspaceRemovesValue={true}
                 allowCustomValue={true}
-                isClearable={true}
                 menuPlacement="auto"
               />
             </EditorField>

--- a/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
+++ b/src/components/query/visual-query-builder/VisualQueryBuilder.tsx
@@ -37,7 +37,7 @@ export function VisualQueryBuilder(props: Props) {
   const defaultRegion: SelectableValue<Region> = {
     label: `Default`,
     description: datasource.options?.defaultRegion,
-    value: undefined,
+    value: 'default',
   };
   const regions = query.region ? [defaultRegion, ...regionOptions] : regionOptions;
   const currentQueryType = siteWiseQueryTypes.find((v) => v.value === query.queryType);

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -20,12 +20,12 @@ export const supportedRegions = [
 ] as const;
 
 // backend is configured to use the user's configured default region when /query
-// is called with an empty string for the region
-export const DEFAULT_REGION = '';
+// is called with "default" region or empty string
+export const DEFAULT_REGION = 'default';
 
 export type DefaultRegion = typeof DEFAULT_REGION;
 
-export type Region = (typeof supportedRegions)[number] | DefaultRegion;
+export type Region = (typeof supportedRegions)[number] | DefaultRegion | '';
 
 export const regionOptions = supportedRegions.map((v) => ({
   value: v,


### PR DESCRIPTION
Fixes https://github.com/grafana/iot-sitewise-datasource/issues/551
Also set isClearable to false, since it shouldn't be possible for users to clear the region, since Default is one of the options

<img width="500" height="498" alt="Screenshot 2025-08-13 at 10 56 32" src="https://github.com/user-attachments/assets/f368fc3b-e976-4e4c-9bb1-b2d2d754274b" />

<img width="500" height="635" alt="Screenshot 2025-08-13 at 10 18 47" src="https://github.com/user-attachments/assets/0765dad1-b298-45de-816f-701a8f761fbd" />
