### PR TITLE
Fix CI workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         environment: [dev, ops, prod]
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v3
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v4.2.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI-plugins
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v3
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v4.2.0
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION

**What this PR does / why we need it**:
We need a newer version of the workflows to unblock e2e tests.