### PR TITLE
chore: add debug logs for raw property alias fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@eslint/js": "^10.0.1",
     "@grafana/aws-sdk": "0.10.2",
     "@grafana/eslint-config": "^9.0.0",
-    "@grafana/plugin-e2e": "^3.4.11",
+    "@grafana/plugin-e2e": "3.4.12",
     "@grafana/tsconfig": "^2.0.1",
     "@playwright/test": "1.58.2",
     "@stylistic/eslint-plugin-ts": "^4.2.0",

--- a/pkg/resource/caching_resource_provider.go
+++ b/pkg/resource/caching_resource_provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/iotsitewise"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/patrickmn/go-cache"
 )
 
@@ -46,6 +47,9 @@ func (cp *cachingResourceProvider) Property(ctx context.Context, assetId string,
 	if ok {
 		a, ok := val.(iotsitewise.DescribeAssetPropertyOutput)
 		if ok {
+			if isRawPropertyAliasFallback(&a, propertyAlias) {
+				log.DefaultLogger.FromContext(ctx).Debug("SiteWise property metadata cache hit for raw property alias fallback metadata")
+			}
 			return &a, nil
 		}
 	}

--- a/pkg/resource/sitewise.go
+++ b/pkg/resource/sitewise.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iotsitewise"
 	iotsitewisetypes "github.com/aws/aws-sdk-go-v2/service/iotsitewise/types"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
 	"github.com/grafana/iot-sitewise-datasource/pkg/sitewise/client"
 )
@@ -53,6 +54,7 @@ func (rp *SitewiseResources) Property(ctx context.Context, assetId string, prope
 			})
 		}
 
+		log.DefaultLogger.FromContext(ctx).Debug("SiteWise alias lookup did not resolve asset/property IDs; using raw property alias fallback metadata")
 		return defaultOutput, nil
 	}
 
@@ -69,4 +71,16 @@ func (rp *SitewiseResources) AssetModel(ctx context.Context, modelId string) (*i
 	})
 
 	return resp, err
+}
+
+func isRawPropertyAliasFallback(property *iotsitewise.DescribeAssetPropertyOutput, propertyAlias string) bool {
+	if property == nil || propertyAlias == "" || property.AssetName == nil || *property.AssetName != "" {
+		return false
+	}
+
+	if property.AssetProperty == nil || property.AssetProperty.Name == nil {
+		return false
+	}
+
+	return *property.AssetProperty.Name == propertyAlias
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,14 @@ export default defineConfig<PluginOptions>({
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:3000',
+    featureToggles: {
+      dashboardNewLayouts: false,
+    },
+    openFeature: {
+      flags: {
+        splashScreen: false,
+      },
+    },
     trace: 'on-first-retry',
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,9 +1578,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-e2e@npm:^3.4.11":
-  version: 3.4.11
-  resolution: "@grafana/plugin-e2e@npm:3.4.11"
+"@grafana/plugin-e2e@npm:3.4.12":
+  version: 3.4.12
+  resolution: "@grafana/plugin-e2e@npm:3.4.12"
   dependencies:
     "@grafana/e2e-selectors": "npm:13.0.0-23624974663"
     semver: "npm:^7.5.4"
@@ -1592,7 +1592,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10c0/58e3b4060cf2cf76a0c0fa683cf0e6af9fcdb20dfff69f6efc2cd3d789f02ab46b54ec68055fd91da07a1998304f89934a89575de96dde84411baf6b1da541af
+  checksum: 10c0/b87340d2cb04bcbcaf7676d61f8f990fd26ba1d8f53cfb922e89a4751ede29bbe61021d770d3a9ebdf4500fe404fe6512ddea03be4d1c08ee15d22e9e5a376e7
   languageName: node
   linkType: hard
 
@@ -7343,7 +7343,7 @@ __metadata:
     "@grafana/aws-sdk": "npm:0.10.2"
     "@grafana/data": "npm:^12.1.0"
     "@grafana/eslint-config": "npm:^9.0.0"
-    "@grafana/plugin-e2e": "npm:^3.4.11"
+    "@grafana/plugin-e2e": "npm:3.4.12"
     "@grafana/plugin-ui": "npm:^0.13.0"
     "@grafana/runtime": "npm:^12.1.0"
     "@grafana/schema": "npm:^12.1.0"


### PR DESCRIPTION
## Summary
- Add debug log lines when SiteWise alias resolution falls back to raw property alias metadata
- Add a debug log line when cached fallback metadata is reused
- These additional debug log lines are for https://github.com/grafana/support-escalations/issues/21107

## Files Changed
- `pkg/resource/sitewise.go`
- `pkg/resource/caching_resource_provider.go`