### PR TITLE
Update 2.6.0 changelog to prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## v2.6.0
 
+- fix: use declared scalar type for timestamps instead of column name override in [#753](https://github.com/grafana/iot-sitewise-datasource/pull/753)
+- chore(deps): update grafana/shared-workflows/ action to in [#759](https://github.com/grafana/iot-sitewise-datasource/pull/759)
+- fix(deps): update backend dependencies in [#758](https://github.com/grafana/iot-sitewise-datasource/pull/758)
+- chore(deps): update grafana/grafana-enterprise:latest docker digest to 8b65309 in [#757](https://github.com/grafana/iot-sitewise-datasource/pull/757)
+- chore(deps): update grafana/shared-workflows/ action to in [#755](https://github.com/grafana/iot-sitewise-datasource/pull/755)
+- fix(deps): update backend dependencies in [#751](https://github.com/grafana/iot-sitewise-datasource/pull/751)
+- chore(deps): update dependency webpack-cli to v7 in [#750](https://github.com/grafana/iot-sitewise-datasource/pull/750)
+- chore(deps): update module google.golang.org/grpc to v1.79.3 [security] in [#749](https://github.com/grafana/iot-sitewise-datasource/pull/749)
+- fix(deps): update backend dependencies in [#746](https://github.com/grafana/iot-sitewise-datasource/pull/746)
+- chore(deps): update grafana/grafana-enterprise:latest docker digest to 8e8fc4c in [#745](https://github.com/grafana/iot-sitewise-datasource/pull/745)
+- chore(deps): update actions/create-github-app-token digest to fee1f7d in [#744](https://github.com/grafana/iot-sitewise-datasource/pull/744)
+- Bump grafana-aws-sdk-react and prepare 2.6.0 release in [#743](https://github.com/grafana/iot-sitewise-datasource/pull/743)
+- chore(deps): update frontend dependencies (major) in [#739](https://github.com/grafana/iot-sitewise-datasource/pull/739)
 - Add sessionToken handling to support Grafana Assume Role in [#741](https://github.com/grafana/iot-sitewise-datasource/pull/741)
 - fix(deps): update backend dependencies in [#738](https://github.com/grafana/iot-sitewise-datasource/pull/738)
 - chore(deps): pin grafana/grafana-enterprise docker tag to 582fc54 in [#736](https://github.com/grafana/iot-sitewise-datasource/pull/736)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## v2.6.0
 
 - chore: add debug logs for raw property alias fallback in [#756](https://github.com/grafana/iot-sitewise-datasource/pull/756)
-- Update codeowners in [#761](https://github.com/grafana/iot-sitewise-datasource/pull/761)
+- Update CODEOWNERS in [#761](https://github.com/grafana/iot-sitewise-datasource/pull/761)
 - fix: use declared scalar type for timestamps instead of column name override in [#753](https://github.com/grafana/iot-sitewise-datasource/pull/753)
 - chore(deps): update grafana/shared-workflows/ action to in [#759](https://github.com/grafana/iot-sitewise-datasource/pull/759)
 - fix(deps): update backend dependencies in [#758](https://github.com/grafana/iot-sitewise-datasource/pull/758)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## v2.6.0
 
+- chore: add debug logs for raw property alias fallback in [#756](https://github.com/grafana/iot-sitewise-datasource/pull/756)
+- Update codeowners in [#761](https://github.com/grafana/iot-sitewise-datasource/pull/761)
 - fix: use declared scalar type for timestamps instead of column name override in [#753](https://github.com/grafana/iot-sitewise-datasource/pull/753)
 - chore(deps): update grafana/shared-workflows/ action to in [#759](https://github.com/grafana/iot-sitewise-datasource/pull/759)
 - fix(deps): update backend dependencies in [#758](https://github.com/grafana/iot-sitewise-datasource/pull/758)

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -70,6 +70,8 @@
     "combobox",
     "Cacheable",
     "Stalebot",
+    "CODEOWNERS",
+    "codeowners",
     "gofmt",
     "eslintcache",
     "lefthook",


### PR DESCRIPTION
A release was supposed to be made for [2.6.0](https://github.com/grafana/iot-sitewise-datasource/pull/743) but it was never published. This PR updates the changelog for 2.6.0 to include commits that were merged since that commit so that we can kick of a release.