### PR TITLE
Fix 400 error when batched IoT SiteWise queries paginate past completed entries

### DIFF
--- a/pkg/sitewise/api/util.go
+++ b/pkg/sitewise/api/util.go
@@ -35,6 +35,13 @@ func getNextToken(query models.BaseQuery) *string {
 		}
 		// If there are any issues looking up the nextToken it should error and bubble up
 		nextToken := query.NextTokens[entryId]
+		// A map miss (e.g. an entry that completed pagination on a prior page) yields
+		// the empty string. Sending an empty nextToken to the IoT SiteWise API is
+		// rejected with a 400 InvalidRequestException, so omit it (return nil) to end
+		// pagination for that entry, mirroring the single-entry branch below.
+		if nextToken == "" {
+			return nil
+		}
 		return aws.String(nextToken)
 	} else {
 		if query.NextToken == "" {

--- a/pkg/sitewise/api/util_internal_test.go
+++ b/pkg/sitewise/api/util_internal_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/grafana/iot-sitewise-datasource/pkg/models"
+	"github.com/grafana/iot-sitewise-datasource/pkg/util"
+)
+
+func TestGetNextToken(t *testing.T) {
+	const (
+		assetID    = "11111111-1111-1111-1111-111111111111"
+		propertyID = "22222222-2222-2222-2222-222222222222"
+		alias      = "/my/property/alias"
+	)
+	batchedEntryID := *util.GetEntryIdFromAssetProperty(assetID, propertyID)
+	aliasEntryID := *util.GetEntryIdFromPropertyAlias(alias)
+
+	tests := []struct {
+		name  string
+		query models.BaseQuery
+		want  *string
+	}{
+		{
+			name:  "no token returns nil",
+			query: models.BaseQuery{},
+			want:  nil,
+		},
+		{
+			name:  "single-entry non-empty token is forwarded",
+			query: models.BaseQuery{NextToken: "abc123"},
+			want:  stringPtr("abc123"),
+		},
+		{
+			name:  "single-entry empty token returns nil",
+			query: models.BaseQuery{NextToken: ""},
+			want:  nil,
+		},
+		{
+			name: "batched entry with non-empty token is forwarded",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{AssetId: assetID, PropertyId: propertyID},
+				},
+				NextTokens: map[string]string{batchedEntryID: "page2token"},
+			},
+			want: stringPtr("page2token"),
+		},
+		{
+			// Regression test for https://github.com/grafana/iot-sitewise-datasource/issues/765
+			// A map miss (entry that finished paginating on a prior page) yields "".
+			// getNextToken must return nil, not aws.String(""), to avoid a 400
+			// InvalidRequestException from BatchGetAssetPropertyValueHistory.
+			name: "batched entry with map miss returns nil (issue #765)",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{AssetId: assetID, PropertyId: propertyID},
+				},
+				NextTokens: map[string]string{"some-other-entry": "page2token"},
+			},
+			want: nil,
+		},
+		{
+			name: "batched entry with explicitly empty token returns nil (issue #765)",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{AssetId: assetID, PropertyId: propertyID},
+				},
+				NextTokens: map[string]string{batchedEntryID: ""},
+			},
+			want: nil,
+		},
+		{
+			name: "batched entry keyed by property alias with non-empty token is forwarded",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{PropertyAlias: alias},
+				},
+				NextTokens: map[string]string{aliasEntryID: "aliasToken"},
+			},
+			want: stringPtr("aliasToken"),
+		},
+		{
+			name: "batched entry keyed by property alias with map miss returns nil (issue #765)",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{PropertyAlias: alias},
+				},
+				NextTokens: map[string]string{"some-other-entry": "aliasToken"},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getNextToken(tt.query)
+			switch {
+			case tt.want == nil && got != nil:
+				t.Fatalf("expected nil nextToken, got %q", *got)
+			case tt.want != nil && got == nil:
+				t.Fatalf("expected nextToken %q, got nil", *tt.want)
+			case tt.want != nil && got != nil && *tt.want != *got:
+				t.Fatalf("expected nextToken %q, got %q", *tt.want, *got)
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`getNextToken` returned `aws.String("")` for batched time-series queries when an entry's token was absent from the `NextTokens` map (a map miss). This happens once an entry has completed paginating on an earlier page: the frontend (`src/getNextQueries.ts`) only writes `nextTokens[entryId]` when the token is truthy, so the completed entry drops out of the map, and on the next continuation call the backend recomputes that `entryId`, misses, and gets the Go zero value `""`.

A non-nil pointer to an empty string is serialized onto `BatchGetAssetPropertyValueHistoryInput.NextToken` and forwarded verbatim by the SDK paginator on its first request, so IoT SiteWise rejects it:

```
InvalidRequestException: 2 validation errors detected:
Value '' at 'nextToken' failed to satisfy constraint:
Member must satisfy regular expression pattern: [A-Za-z0-9+/=]+;
Value '' at 'nextToken' failed to satisfy constraint:
Member must have length greater than or equal to 1
```

This surfaces as an HTTP 500 in Grafana for any panel whose time range is large enough to require multi-page pagination (commonly > ~3 hours). It affects all batched query paths that share `getNextToken` (property history, property value, property aggregate).

The fix mirrors the existing single-entry branch, which already guards `query.NextToken == ""` → `return nil`. Returning `nil` omits the token, which correctly ends pagination for that entry instead of sending an invalid request. `getNextToken` is byte-identical on `main` and tags v2.4.2 / v2.5.1 / v2.6.0, so this bug reproduces on every currently published version.

**Which issue(s) this PR fixes**:

Fixes #765

**Special notes for your reviewer**:

- Adds `pkg/sitewise/api/util_internal_test.go` (internal test, since `getNextToken` is unexported) covering both branches: single-entry (empty/non-empty) and batched (non-empty, map-miss, explicit-empty, alias-keyed). The map-miss and explicit-empty cases fail without this change.
- No behavior change for the non-empty token case — only an empty resolved token now ends pagination (returns `nil`) instead of producing a guaranteed-invalid request.
- Adding the `changelog` label as this is a user-facing bug fix.