### PR TITLE
fix(api): don't send empty nextToken when batched IoT SiteWise queries finish paginating

### DIFF
--- a/pkg/sitewise/api/util.go
+++ b/pkg/sitewise/api/util.go
@@ -33,8 +33,16 @@ func getNextToken(query models.BaseQuery) *string {
 		} else {
 			entryId = *util.GetEntryIdFromPropertyAlias(entry.PropertyAlias)
 		}
-		// If there are any issues looking up the nextToken it should error and bubble up
+		// A map miss (e.g. an entry that completed pagination on a prior page) yields
+		// the empty string, same as an explicitly empty token. Sending an empty
+		// nextToken to the IoT SiteWise API is rejected with a 400
+		// InvalidRequestException, so treat both cases as end-of-pagination for
+		// that entry and omit the token (return nil), mirroring the single-entry
+		// branch below.
 		nextToken := query.NextTokens[entryId]
+		if nextToken == "" {
+			return nil
+		}
 		return aws.String(nextToken)
 	} else {
 		if query.NextToken == "" {

--- a/pkg/sitewise/api/util_internal_test.go
+++ b/pkg/sitewise/api/util_internal_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/grafana/iot-sitewise-datasource/pkg/models"
+	"github.com/grafana/iot-sitewise-datasource/pkg/util"
+)
+
+func TestGetNextToken(t *testing.T) {
+	const (
+		assetID    = "11111111-1111-1111-1111-111111111111"
+		propertyID = "22222222-2222-2222-2222-222222222222"
+		alias      = "/my/property/alias"
+	)
+	batchedEntryID := *util.GetEntryIdFromAssetProperty(assetID, propertyID)
+	aliasEntryID := *util.GetEntryIdFromPropertyAlias(alias)
+
+	tests := []struct {
+		name  string
+		query models.BaseQuery
+		want  *string
+	}{
+		{
+			name:  "no token returns nil",
+			query: models.BaseQuery{},
+			want:  nil,
+		},
+		{
+			name:  "single-entry non-empty token is forwarded",
+			query: models.BaseQuery{NextToken: "abc123"},
+			want:  stringPtr("abc123"),
+		},
+		{
+			name:  "single-entry empty token returns nil",
+			query: models.BaseQuery{NextToken: ""},
+			want:  nil,
+		},
+		{
+			name: "batched entry with non-empty token is forwarded",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{AssetId: assetID, PropertyId: propertyID},
+				},
+				NextTokens: map[string]string{batchedEntryID: "page2token"},
+			},
+			want: stringPtr("page2token"),
+		},
+		{
+			// Regression test for https://github.com/grafana/iot-sitewise-datasource/issues/765
+			// A map miss (entry that finished paginating on a prior page) yields "".
+			// getNextToken must return nil, not aws.String(""), to avoid a 400
+			// InvalidRequestException from BatchGetAssetPropertyValueHistory.
+			name: "batched entry with map miss returns nil (issue #765)",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{AssetId: assetID, PropertyId: propertyID},
+				},
+				NextTokens: map[string]string{"some-other-entry": "page2token"},
+			},
+			want: nil,
+		},
+		{
+			name: "batched entry with explicitly empty token returns nil (issue #765)",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{AssetId: assetID, PropertyId: propertyID},
+				},
+				NextTokens: map[string]string{batchedEntryID: ""},
+			},
+			want: nil,
+		},
+		{
+			name: "batched entry keyed by property alias with non-empty token is forwarded",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{PropertyAlias: alias},
+				},
+				NextTokens: map[string]string{aliasEntryID: "aliasToken"},
+			},
+			want: stringPtr("aliasToken"),
+		},
+		{
+			name: "batched entry keyed by property alias with map miss returns nil (issue #765)",
+			query: models.BaseQuery{
+				AssetPropertyEntries: []models.AssetPropertyEntry{
+					{PropertyAlias: alias},
+				},
+				NextTokens: map[string]string{"some-other-entry": "aliasToken"},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getNextToken(tt.query)
+			switch {
+			case tt.want == nil && got != nil:
+				t.Fatalf("expected nil nextToken, got %q", *got)
+			case tt.want != nil && got == nil:
+				t.Fatalf("expected nextToken %q, got nil", *tt.want)
+			case tt.want != nil && got != nil && *tt.want != *got:
+				t.Fatalf("expected nextToken %q, got %q", *tt.want, *got)
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
- Recreates #808 (thanks @ashishranjan738 for the original fix) with signed commits so it can pass CI/CLA — the original author is no longer active to address review feedback.
- `getNextToken` returned `aws.String("")` on a `NextTokens` map miss (an entry that finished paginating on a prior page); IoT SiteWise rejects an empty `nextToken` with a 400, surfacing as a 500 in Grafana for any time range needing pagination (~3h+). Now returns `nil` to omit the token, mirroring the existing single-entry guard.
- Also clarifies a stale comment flagged in Copilot's review of #808.
- Checks: `go build ./...`, `go vet ./...`, `go test ./pkg/...` all pass, including new regression tests for #765.

Fixes #765