### PR TITLE
Prepare release 2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.6.2
+
+- fix(security): bump out-of-SLO serialize-javascript to 7.0.7 in [#837](https://github.com/grafana/iot-sitewise-datasource/pull/837)
+
 ## v2.6.1
 
 - Fixed out of SLO CVEs in [#834](https://github.com/grafana/iot-sitewise-datasource/pull/834)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-sitewise-datasource",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "View IoT Sitewise data in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
- Bump version to `2.6.2` in `package.json`
- Update `CHANGELOG.md` with the change since [v2.6.1](https://github.com/grafana/iot-sitewise-datasource/releases/tag/v2.6.1) (released 2026-08-04): the serialize-javascript security fix
- After merge: run the Plugins CI CD workflow per CONTRIBUTING.md